### PR TITLE
expose tx created and buyer fields, use pk as uri attribute instead of uuid

### DIFF
--- a/lib/transactions/models.py
+++ b/lib/transactions/models.py
@@ -20,17 +20,16 @@ class Transaction(Model):
     buyer = models.ForeignKey('buyers.Buyer', blank=True, null=True,
                               db_index=True)
     currency = models.CharField(max_length=3, blank=True)
-    provider = models.PositiveIntegerField(
-                              choices=constants.SOURCES_CHOICES)
+    provider = models.PositiveIntegerField(choices=constants.SOURCES_CHOICES)
     related = models.ForeignKey('self', blank=True, null=True,
-                              on_delete=models.PROTECT)
+                                on_delete=models.PROTECT)
     seller_product = models.ForeignKey('sellers.SellerProduct', db_index=True)
     status = models.PositiveIntegerField(default=constants.STATUS_DEFAULT,
-                              choices=constants.STATUSES_CHOICES)
+                                         choices=constants.STATUSES_CHOICES)
     source = models.CharField(max_length=255, blank=True, null=True,
                               db_index=True)
     type = models.PositiveIntegerField(default=constants.TYPE_DEFAULT,
-                              choices=constants.TYPES_CHOICES)
+                                       choices=constants.TYPES_CHOICES)
     # Lots of IDs.
     # An ID from the provider that can be used for support on this specific
     # transaction. Optional.
@@ -72,15 +71,15 @@ def create_paypal_transaction(sender, **kwargs):
     clean = kwargs['form']
 
     transaction = Transaction.create(
-            amount=clean['amount'],
-            currency=clean['currency'],
-            provider=constants.SOURCE_PAYPAL,
-            seller_product=clean['seller_product'],
-            source=clean.get('source', ''),
-            type=constants.TYPE_PAYMENT,
-            uid_pay=data['pay_key'],
-            uid_support=data['correlation_id'],
-            uuid=data['uuid'])
+        amount=clean['amount'],
+        currency=clean['currency'],
+        provider=constants.SOURCE_PAYPAL,
+        seller_product=clean['seller_product'],
+        source=clean.get('source', ''),
+        type=constants.TYPE_PAYMENT,
+        uid_pay=data['pay_key'],
+        uid_support=data['correlation_id'],
+        uuid=data['uuid'])
     log.info('Transaction: %s, paypal status: %s'
              % (transaction.pk, data['status']))
 
@@ -113,10 +112,10 @@ def create_bango_transaction(sender, **kwargs):
     seller_product = form.cleaned_data['seller_product_bango'].seller_product
 
     transaction, c = Transaction.objects.safer_get_or_create(
-            uuid=data['transaction_uuid'],
-            status=constants.STATUS_RECEIVED,
-            provider=constants.SOURCE_BANGO,
-            seller_product=seller_product)
+        uuid=data['transaction_uuid'],
+        status=constants.STATUS_RECEIVED,
+        provider=constants.SOURCE_BANGO,
+        seller_product=seller_product)
     transaction.source = data.get('source', '')
     # uid_support will be set with the transaction id.
     # uid_pay is the uid of the billingConfiguration request.

--- a/lib/transactions/resources.py
+++ b/lib/transactions/resources.py
@@ -1,7 +1,5 @@
 import uuid
 
-from django.conf.urls.defaults import url
-
 from tastypie import fields
 
 from lib.transactions.models import Transaction
@@ -11,18 +9,21 @@ from .forms import UpdateForm
 
 
 class TransactionResource(ModelResource):
+    buyer = fields.ToOneField(
+        'lib.buyers.resources.BuyerResource',
+        'buyer', blank=True, full=False, null=True)
     seller_product = fields.ToOneField(
-                'lib.sellers.resources.SellerProductResource',
-                'seller_product', blank=True, full=False, null=True)
+        'lib.sellers.resources.SellerProductResource',
+        'seller_product', blank=True, full=False, null=True)
     related = fields.ToOneField(
-                'lib.transactions.resources.TransactionResource',
-                'related', blank=True, full=False, null=True)
+        'lib.transactions.resources.TransactionResource',
+        'related', blank=True, full=False, null=True)
 
     class Meta(ModelResource.Meta):
         queryset = Transaction.objects.filter()
         fields = ['uuid', 'seller_product', 'amount', 'currency', 'provider',
                   'uid_pay', 'uid_support', 'type', 'status', 'related',
-                  'notes']
+                  'notes', 'created', 'buyer']
         list_allowed_methods = ['get', 'post']
         allowed_methods = ['get', 'patch']
         resource_name = 'transaction'
@@ -38,15 +39,6 @@ class TransactionResource(ModelResource):
             return (super(TransactionResource, self)
                     .update_in_place(request, original_data, new_data))
         raise self.form_errors(form)
-
-    def override_urls(self):
-         return [
-            url(r"^(?P<resource_name>transaction)/(?P<uuid>.*)/$",
-                self.wrap_view('dispatch_detail'),
-                name="api_dispatch_detail"),
-         ]
-
-    prepend_urls = override_urls
 
     def hydrate_uuid(self, bundle):
         bundle.data.setdefault('uuid', str(uuid.uuid4()))

--- a/lib/transactions/tests/test_api.py
+++ b/lib/transactions/tests/test_api.py
@@ -18,14 +18,13 @@ class TestSeller(APITest):
         self.list_url = self.get_list_url('transaction')
         self.seller, self.paypal, self.product = (
             make_seller_paypal('paypal:%s' % self.uuid))
-        self.trans = Transaction.objects.create(amount=5,
-                                            seller_product=self.product,
-                                            provider=constants.SOURCE_PAYPAL,
-                                            uuid=self.uuid)
+        self.trans = Transaction.objects.create(
+            amount=5, seller_product=self.product,
+            provider=constants.SOURCE_PAYPAL, uuid=self.uuid)
         self.detail_url = reverse('api_dispatch_detail',
                                   kwargs={'api_name': self.api_name,
                                           'resource_name': 'transaction',
-                                          'uuid': self.uuid})
+                                          'pk': self.trans.pk})
 
     def test_list_allowed(self):
         self.allowed_verbs(self.list_url, ['get', 'post'])


### PR DESCRIPTION
prepend_urls doesn't run when using tastypie.fields.ToOne which causes some of the resource URIs to slug off of the uuid and some off of the pk.
