### PR TITLE
give webpay data about if the buyer was locked out (bug 856150)

### DIFF
--- a/lib/buyers/models.py
+++ b/lib/buyers/models.py
@@ -15,6 +15,7 @@ class Buyer(Model):
     pin_confirmed = models.BooleanField(default=False)
     pin_failures = models.IntegerField(default=0)
     pin_locked_out = models.DateTimeField(blank=True, null=True)
+    pin_was_locked_out = models.BooleanField(default=False)
     active = models.BooleanField(default=True, db_index=True)
     new_pin = HashField(blank=True, null=True)
     needs_pin_reset = models.BooleanField(default=False)
@@ -34,9 +35,18 @@ class Buyer(Model):
 
         return True
 
+    @property
+    def check_was_lock_status_and_reset(self):
+        if self.pin_was_locked_out:
+            self.pin_was_locked_out = False
+            self.save()
+            return True
+        return False
+
     def clear_lockout(self):
         self.pin_failures = 0
         self.pin_locked_out = None
+        self.pin_was_locked_out = True
         self.save()
 
     def incr_lockout(self):

--- a/lib/buyers/tests/test_models.py
+++ b/lib/buyers/tests/test_models.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 
-from aesfield.field import EncryptedField
-from nose.tools import eq_
-
 from django.conf import settings
 from django.test import TestCase
+
+from aesfield.field import EncryptedField
+from nose.tools import eq_
 
 from lib.buyers.models import Buyer, BuyerPaypal
 
@@ -74,6 +74,12 @@ class TestLockout(TestCase):
         self.buyer.clear_lockout()
         eq_(self.buyer.pin_failures, 0)
         eq_(self.buyer.pin_locked_out, None)
+        assert self.buyer.pin_was_locked_out
+
+    def test_was_locked_out(self):
+        self.buyer.pin_was_locked_out = True
+        assert self.buyer.check_was_lock_status_and_reset
+        assert not self.buyer.pin_was_locked_out
 
     def test_under_timeout(self):
         self.buyer.pin_locked_out = (datetime.now() -

--- a/migrations/35-add-pin-was-locked-to-buyer.sql
+++ b/migrations/35-add-pin-was-locked-to-buyer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `buyer` ADD COLUMN `pin_was_locked_out` boolean NOT NULL DEFAULT 0;


### PR DESCRIPTION
This is the solitude side of https://github.com/mozilla/webpay/commit/7305747f1ac6b44c835650f0fcd67fac504cef78
