### PR TITLE
Pass through package size for packaged apps (bug 878876)

### DIFF
--- a/lib/bango/forms.py
+++ b/lib/bango/forms.py
@@ -152,7 +152,6 @@ class CreateBangoNumberForm(forms.Form):
     @property
     def bango_data(self):
         result = self.cleaned_data.copy()
-        result['applicationSize'] = 1
         result['packageId'] = result['seller_bango'].package_id
         del result['seller_bango']
         del result['seller_product']
@@ -198,11 +197,16 @@ class CreateBillingConfigurationForm(SellerProductForm):
     transaction_uuid = forms.CharField()
     user_uuid = forms.CharField()
     icon_url = forms.URLField(required=False)
+    application_size = forms.IntegerField(required=False)  # In bytes.
 
     @property
     def bango_data(self):
         data = super(CreateBillingConfigurationForm, self).bango_data
         data['externalTransactionId'] = data.pop('transaction_uuid')
+        # Converting the application size in rounded kilobytes (default = 1).
+        application_size = data.get('application_size', 1) or 1
+        application_size = long(application_size) / 1024 or 1
+        data['application_size'] = int(application_size)
         del data['prices']
         return data
 

--- a/lib/bango/resources/billing.py
+++ b/lib/bango/resources/billing.py
@@ -107,7 +107,7 @@ class CreateBillingConfigurationResource(Resource):
         config = billing.factory.create('ArrayOfBillingConfigurationOption')
         configs = {
             'APPLICATION_CATEGORY_ID': '18',
-            'APPLICATION_SIZE_KB': 2,
+            'APPLICATION_SIZE_KB': data['application_size'],
             # Tell Bango to use our same transaction expiry logic.
             # However, we pad it by 60 seconds to show a prettier Mozilla user
             # error in the case of a real timeout.

--- a/lib/bango/tests/test_forms.py
+++ b/lib/bango/tests/test_forms.py
@@ -5,7 +5,7 @@ from django.conf import settings
 import mock
 from nose.tools import eq_, ok_
 
-from ..forms import (CreateBankDetailsForm,
+from ..forms import (CreateBankDetailsForm, CreateBillingConfigurationForm,
                      CreateBillingConfigurationForm as BillingForm, EventForm,
                      PackageForm, PriceForm, VatNumberForm)
 from .samples import (event_notification, good_address, good_bank_details,
@@ -14,6 +14,8 @@ from lib.sellers.models import Seller, SellerProduct
 from lib.transactions import constants
 from lib.transactions.models import Transaction
 from solitude.base import APITest
+
+import samples
 
 
 @mock.patch('lib.bango.forms.URLField.clean')
@@ -94,6 +96,19 @@ class TestPackage(APITest):
             form = PackageForm(good_address)
             ok_(form.is_valid())
             eq_(form.bango_data['eventNotificationURL'], 'http://f.com')
+
+    def compute_application_size(self, data, submitted_size, computed_size):
+        data['application_size'] = submitted_size
+        form = CreateBillingConfigurationForm(data)
+        ok_(form.is_valid())
+        eq_(form.bango_data['application_size'], computed_size)
+
+    def test_submit_bango_number_with_application_size(self, clean):
+        data = samples.good_billing_request
+        data['transaction_uuid'] = 'foo'
+        self.compute_application_size(data, None, 1)
+        self.compute_application_size(data, 300, 1)
+        self.compute_application_size(data, 388096, 379)
 
 
 class TestVat(APITest):


### PR DESCRIPTION
Add the ability to optionally pass an `applicationSize` to the `CreateBangoNumberForm`
