### PR TITLE
Give every object in solitude an e-tag (bug 895172)

### DIFF
--- a/lib/bango/resources/status.py
+++ b/lib/bango/resources/status.py
@@ -6,8 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 
 from rest_framework.exceptions import ParseError
-from rest_framework.mixins import (CreateModelMixin, ListModelMixin,
-                                   RetrieveModelMixin)
+from rest_framework.mixins import CreateModelMixin
 from rest_framework.response import Response
 from rest_framework.serializers import HyperlinkedModelSerializer, Serializer
 from rest_framework.viewsets import GenericViewSet, ViewSet
@@ -20,7 +19,8 @@ from lib.bango.resources.billing import CreateBillingConfigurationResource
 from lib.sellers.models import SellerProductBango
 from lib.transactions.constants import SOURCE_BANGO
 
-from solitude.base import CompatRelatedField
+from solitude.base import (CompatRelatedField, ListModelMixin,
+    RetrieveModelMixin)
 from solitude.logger import getLogger
 
 log = getLogger('s.bango')

--- a/lib/services/resources.py
+++ b/lib/services/resources.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 import traceback
 import urlparse
 

--- a/migrations/32-populate-public-id.py
+++ b/migrations/32-populate-public-id.py
@@ -1,17 +1,1 @@
-import uuid
-
-from django.db.utils import DatabaseError
-
-from lib.sellers.models import SellerProduct
-
-
-def run():
-    try:
-        for seller in SellerProduct.objects.all():
-            seller.public_id = str(uuid.uuid4())
-            seller.save()
-    except DatabaseError, exc:
-        if "Unknown column 'seller_product.access'" in str(exc):
-            # We don't need to worry about this migration then.
-            return
-        raise
+# Removed to be able to run future migrations altering the SellerProduct model.

--- a/migrations/37-add-counter-field.sql
+++ b/migrations/37-add-counter-field.sql
@@ -1,0 +1,10 @@
+ALTER TABLE `buyer` ADD COLUMN `counter` bigint(20) NULL DEFAULT 0;
+ALTER TABLE `buyer_paypal` ADD COLUMN `counter` bigint(20) NULL DEFAULT 0;
+ALTER TABLE `delayable` ADD COLUMN `counter` bigint(20) NULL DEFAULT 0;
+ALTER TABLE `seller` ADD COLUMN `counter` bigint(20) NULL DEFAULT 0;
+ALTER TABLE `seller_bango` ADD COLUMN `counter` bigint(20) NULL DEFAULT 0;
+ALTER TABLE `seller_paypal` ADD COLUMN `counter` bigint(20) NULL DEFAULT 0;
+ALTER TABLE `seller_product` ADD COLUMN `counter` bigint(20) NULL DEFAULT 0;
+ALTER TABLE `seller_product_bango` ADD COLUMN `counter` bigint(20) NULL DEFAULT 0;
+ALTER TABLE `status_bango` ADD COLUMN `counter` bigint(20) NULL DEFAULT 0;
+ALTER TABLE `transaction` ADD COLUMN `counter` bigint(20) NULL DEFAULT 0;

--- a/solitude/settings/base.py
+++ b/solitude/settings/base.py
@@ -50,6 +50,7 @@ if os.environ.get('MEMCACHE_URL'):
 LOCALE_PATHS = ()
 USE_I18N = False
 USE_L10N = False
+USE_ETAGS = True
 
 SOLITUDE_PROXY = os.environ.get('SOLITUDE_PROXY', 'disabled') == 'enabled'
 if SOLITUDE_PROXY:


### PR DESCRIPTION
Still missing:
- [x] a validation about the `epoch_micro` approach
- [x] SQL queries to create the added field
- [x] a discussion about the situation of PUT/PATCH requests without an `etag`
- [x] a factorization of the code to extract mixins/resources dedicated to a given REST framework (note that `UpdateModelMixin` is not in use/tested for now)
- [x] switching to `counter` + `pk` as a unique etag
