### PR TITLE
Return a list of failed apps (bug 895199)

### DIFF
--- a/lib/services/tests.py
+++ b/lib/services/tests.py
@@ -5,7 +5,6 @@ from django.core.cache import cache
 from django.core.urlresolvers import reverse
 
 from mock import patch
-from nose import SkipTest
 from nose.tools import eq_
 
 

--- a/solitude/urls.py
+++ b/solitude/urls.py
@@ -39,6 +39,10 @@ services_patterns = patterns('lib.services.resources',
     url(r'^logs/', 'logs', name='services.log'),
     url(r'^status/', 'status', name='services.status'),
     url(r'^request/', 'request_resource', name='services.request'),
+    url(r'^failures/transactions/', 'transactions_failures',
+        name='services.failures.transactions'),
+    url(r'^failures/statuses/', 'statuses_failures',
+        name='services.failures.statuses'),
 )
 
 urlpatterns = patterns('',


### PR DESCRIPTION
To be discussed:
- [x] the end-goal of that API, who will consume it and how?
- [x] the potential split of transaction failures vs. statuses failures
- [x] the structure/content of information returned
- [x] the use of a REST framework vs. a services' function-based view
