### PR TITLE
refactor login resource to be a bit more standard (bug 888075)

### DIFF
--- a/lib/bango/client.py
+++ b/lib/bango/client.py
@@ -216,6 +216,13 @@ mock_data = {
         'sbiAgreementAccepted': True,
         'acceptedSBIAgreement': datetime.today,
         'sbiAgreementExpires': datetime.today,
+    },
+    'GetEmailAddresses': {
+        'adminPersonId': '123',
+        'adminEmailAddress': 'foo@bar.com'
+    },
+    'GetAutoAuthenticationLoginToken': {
+        'authenticationToken': ltime
     }
 }
 
@@ -270,3 +277,19 @@ def get_client():
     if settings.BANGO_PROXY:
         return ClientProxy()
     return Client()
+
+
+class Form(object):
+    """A fake form to reformat Bango errors into form errors."""
+
+    def __init__(self, errors):
+        self.errors = errors
+
+
+def format_client_error(key, exc):
+    """
+    Define error_lookup as a dictionary on a resource. If the error from
+    Bango maps to a form field we'll put the error on that form field.
+    Otherwise it gets assigned to __all__.
+    """
+    return Form({key: [exc.message], '__bango__': exc.id, '__type__': 'bango'})

--- a/lib/bango/errors.py
+++ b/lib/bango/errors.py
@@ -18,7 +18,3 @@ class BangoFormError(BangoError):
 
 class ProxyError(Exception):
     """The proxy returned something we didn't like."""
-
-
-class LoginError(Exception):
-    """The auto-login token for the Bango Vendor Portal can't be retrieved."""

--- a/lib/bango/resources/cached.py
+++ b/lib/bango/resources/cached.py
@@ -1,20 +1,13 @@
 from django.core.urlresolvers import reverse
 
-from solitude.base import Cached, Resource as BaseResource
-from ..client import get_client, response_to_dict
+from solitude.base import Cached, Resource as TastypieBaseResource
+from ..client import format_client_error, get_client, response_to_dict
 from ..errors import BangoFormError
 from ..signals import create
 
 
-class Form:
-    """A fake form to pass through to form_errors"""
-
-    def __init__(self, errors):
-        self.errors = errors
-
-
 class BangoResource(object):
-    """A mixin that requires BaseResource to handle Bango form errors."""
+    """A mixin that requires TastypieBaseResource to handle Bango form errors."""
 
     def client(self, method, data, raise_on=None, client=None):
         """
@@ -37,19 +30,13 @@ class BangoResource(object):
             return self.form_errors(res)
 
     def handle_form_error(self, exc):
-        """
-        Define error_lookup as a dictionary on a resource. If the error from
-        Bango maps to a form field we'll put the error on that form field.
-        Otherwise it gets assigned to __all__.
-        """
         key = getattr(self, 'error_lookup', {}).get(exc.id, '__all__')
-        return Form({key: [exc.message], '__bango__': exc.id,
-                     '__type__': 'bango'})
+        return format_client_error(key, exc)
 
 
-class Resource(BaseResource, BangoResource):
+class Resource(TastypieBaseResource, BangoResource):
 
-    class Meta(BaseResource.Meta):
+    class Meta(TastypieBaseResource.Meta):
         object_class = Cached
 
     def get_resource_uri(self, bundle):

--- a/lib/bango/resources/login.py
+++ b/lib/bango/resources/login.py
@@ -1,68 +1,55 @@
-from rest_framework import status as http_statuses
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from cached import BangoResource
-from lib.bango.errors import LoginError
+from lib.bango.errors import BangoError
 from lib.bango.forms import GetEmailAddressesForm, GetLoginTokenForm
+from lib.bango.client import format_client_error, get_client
+
+from solitude.base import DRFBaseResource
 
 
-class LoginResource(BangoResource):
+class LoginResource(DRFBaseResource):
 
-    def form_errors(self, form):
-        return {'errors': dict(form.errors.items())}
+    def client(self, method, data, client=None):
+        return getattr(client or get_client(), method)(data)
 
-
-class EmailAddressesResource(LoginResource):
-
-    def get_package_infos(self, request_post):
-        form = GetEmailAddressesForm(request_post)
-        if not form.is_valid():
-            raise LoginError(dict(form.errors.items()))
-        resp = self.client('GetEmailAddresses', form.cleaned_data)
-        if 'errors' in resp:
-            raise LoginError(resp['errors'])
-        return {
-            'packageId': form.cleaned_data['packageId'],
-            'emailAddress': resp['adminEmailAddress'],
-            'personId': resp['adminPersonId'],
-        }
-
-
-class TokenResource(LoginResource):
-
-    def get_authentication_token(self, package_infos):
-        form = GetLoginTokenForm(data=package_infos)
-        if not form.is_valid():
-            raise LoginError(dict(form.errors.items()))
-        resp = self.client('GetAutoAuthenticationLoginToken',
-                           form.cleaned_data)
-        if 'errors' in resp:
-            raise LoginError(resp['errors'])
-
-        return resp['authenticationToken']
+    def client_errors(self, exc):
+        return self.form_errors(format_client_error('__all__', exc))
 
 
 @api_view(['POST'])
 def login(request):
     """
-    First, retrieving package's infos from the package id
+    Retrieve package's infos from the package id
     to be able to later retrieve the authentication token
     given that we do not store any emails/persons ids.
     """
+    resource = LoginResource()
+    form = GetEmailAddressesForm(request.DATA)
+    if not form.is_valid():
+        return resource.form_errors(form)
+
     try:
-        resource = EmailAddressesResource()
-        package_infos = resource.get_package_infos(request.DATA)
-    except LoginError, e:
-        return Response(e.message, status=http_statuses.HTTP_400_BAD_REQUEST)
+        address = resource.client('GetEmailAddresses', form.cleaned_data)
+    except BangoError, exc:
+        return resource.client_errors(exc)
+
+    form = GetLoginTokenForm(data={
+        'packageId': form.cleaned_data['packageId'],
+        'emailAddress': address.adminEmailAddress,
+        'personId': address.adminPersonId,
+    })
+    if not form.is_valid():
+        return resource.form_errors(form)
+
     try:
-        resource = TokenResource()
-        authentication_token = resource.get_authentication_token(package_infos)
-    except LoginError, e:
-        return Response(e.message, status=http_statuses.HTTP_400_BAD_REQUEST)
+        token = resource.client('GetAutoAuthenticationLoginToken',
+                                form.cleaned_data)
+    except BangoError, exc:
+        return resource.client_errors(exc)
 
     return Response({
-        'authentication_token': authentication_token,
-        'person_id': package_infos['personId'],
-        'email_address': package_infos['emailAddress'],
+        'authentication_token': token.authenticationToken,
+        'person_id': address.adminPersonId,
+        'email_address': address.adminEmailAddress,
     })

--- a/lib/delayable/tests.py
+++ b/lib/delayable/tests.py
@@ -49,7 +49,7 @@ class TestDelay(APITest):
 
 class TestTask(APITest):
 
-    @mock.patch('solitude.base.BaseResource.dispatch')
+    @mock.patch('solitude.base.TastypieBaseResource.dispatch')
     def test_dispatch(self, dispatch):
         obj = mock.Mock()
         obj.status_code = 202

--- a/lib/paypal/resources/cached.py
+++ b/lib/paypal/resources/cached.py
@@ -3,12 +3,12 @@ from django.core.urlresolvers import reverse
 
 from lib.paypal.client import get_client
 from lib.paypal.signals import create
-from solitude.base import Cached, Resource as BaseResource
+from solitude.base import Cached, Resource as TastypieBaseResource
 
 
-class Resource(BaseResource):
+class Resource(TastypieBaseResource):
 
-    class Meta(BaseResource.Meta):
+    class Meta(TastypieBaseResource.Meta):
         object_class = Cached
 
     def get_resource_uri(self, bundle):

--- a/samples/bango-basic.py
+++ b/samples/bango-basic.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import json
-import os
 import pprint
 import sys
 import urllib
@@ -8,7 +7,11 @@ import uuid
 
 import requests
 
-root = 'http://localhost:8001'
+try:
+    # Read the root from the command line, rather than hard coding.
+    root = sys.argv[1]
+except:
+    root = 'http://localhost:8001'
 
 
 def call(url, method, data):
@@ -85,7 +88,6 @@ bango_url = ('http://mozilla.com.test.bango.org/login/al.aspx?%s' %
         'authenticationToken': res['authentication_token'],
     }))
 print 'You should be logged in against: ' + bango_url
-# os.popen('open "%s"' % bango_url)
 
 print 'Getting SBI agreement'
 res = call('/bango/sbi/agreement/', 'get', {
@@ -167,7 +169,7 @@ print ('Finance id %s to %s' % (old_financial_id, res['finance_person_id']))
 print 'Request billing configuration.'
 call('/bango/billing/', 'post', {
     'pageTitle': 'yep',
-    'prices': [{'price': 1, 'currency': 'USD'}],
+    'prices': [{'price': 1, 'currency': 'USD', 'method': 1}],
     'transaction_uuid': str(uuid.uuid4()),
     'user_uuid': str(uuid.uuid4()),
     'seller_product_bango': bango_product_uri,

--- a/solitude/tests/test_delay.py
+++ b/solitude/tests/test_delay.py
@@ -5,13 +5,13 @@ from django.test import RequestFactory
 from nose.tools import eq_
 import mock
 
-from solitude.base import BaseResource, APITest
+from solitude.base import TastypieBaseResource, APITest
 from tastypie.exceptions import ImmediateHttpResponse
 from tastypie.resources import Resource
 from tastypie.authorization import Authorization
 
 
-class TestResource(BaseResource, Resource):
+class TestResource(TastypieBaseResource, Resource):
     class Meta:
         authorization = Authorization()
 


### PR DESCRIPTION
this works with MOCK_BANGO = True or False
has less test mocking, because it uses mock_results
doesn't inherit a mixin designed for tastypie in DRF
fixes the sample bango script and allows that to use any server port
removes two Resources which were pointless since they didn't have tests
