### PR TITLE
Adding support for creating zippy products (bug 932583)

### DIFF
--- a/lib/zippy/tests/test_views.py
+++ b/lib/zippy/tests/test_views.py
@@ -32,69 +32,69 @@ class TestAPIView(TestCase):
                                      resource_name='sellers').status_code, 404)
 
 
-class TestListViews(TestCase):
+class TestViews(TestCase):
 
     def setUp(self):
         self.client = Client()
-        self.url = reverse('zippy.api_view',
-                           args=['reference', 'sellers'])
+        self.seller_uuid = 'zippy-seller-uuid'
+        self.product_uuid = 'zippy-product-uuid'
 
-    def test_retrieve_sellers_empty(self):
-        resp = self.client.get(self.url)
-        ok_(resp['Content-Type'].startswith('application/json'))
+    def url_list(self, resource_name):
+        return reverse('zippy.api_view', args=['reference', resource_name])
 
-    def test_create_seller(self):
-        uuid = 'zippy-uuid'
-        seller = {
-            'uuid': uuid,
-            'status': 'ACTIVE',
-            'name': 'John',
-            'email': 'jdoe@example.org',
-        }
-        resp = self.client.post(self.url, seller)
-        seller.update({
-            'resource_pk': '1',
-            'resource_uri': '/sellers/1',
-        })
-        eq_(json.loads(resp.content), seller)
-
-
-class TestItemViews(TestCase):
-
-    def setUp(self):
-        self.client = Client()
-        self.uuid = 'zippy-uuid'
-        self.url_list = reverse('zippy.api_view',
-                                args=['reference', 'sellers'])
-
-    def url(self, pk):
-        return reverse('zippy.api_view',
-                       args=['reference', 'sellers', pk])
+    def url_item(self, resource_name, pk):
+        return reverse('zippy.api_view', args=['reference', resource_name, pk])
 
     def create_seller(self):
         seller = {
-            'uuid': self.uuid,
+            'uuid': self.seller_uuid,
             'status': 'ACTIVE',
             'name': 'John',
             'email': 'jdoe@example.org',
         }
-        self.client.post(self.url_list, seller)
+        self.client.post(self.url_list('sellers'), seller)
         seller.update({
             'resource_pk': '1',
             'resource_uri': '/sellers/1',
         })
         return seller
 
+    def delete_seller(self):
+        self.client.delete(self.url_item('sellers', self.seller_uuid))
+
+
+class TestSellerViews(TestViews):
+
+    def test_retrieve_sellers_empty(self):
+        self.delete_seller()
+        resp = self.client.get(self.url_list('sellers'))
+        ok_(resp['Content-Type'].startswith('application/json'))
+        eq_(json.loads(resp.content), [])
+
+    def test_create_seller(self):
+        seller = {
+            'uuid': self.seller_uuid,
+            'status': 'ACTIVE',
+            'name': 'John',
+            'email': 'jdoe@example.org',
+        }
+        resp = self.client.post(self.url_list('sellers'), seller)
+        seller.update({
+            'resource_pk': '1',
+            'resource_uri': '/sellers/1',
+        })
+        eq_(json.loads(resp.content), seller)
+
     def test_retrieve_seller(self):
         seller = self.create_seller()
-        resp = self.client.get(self.url(self.uuid))
+        resp = self.client.get(self.url_item('sellers', self.seller_uuid))
         eq_(json.loads(resp.content), seller)
         ok_(resp['Content-Type'].startswith('application/json'))
 
     def test_update_seller(self):
         seller = self.create_seller()
         new_name = 'Jack'
-        resp = self.client.put(self.url(self.uuid),
+        resp = self.client.put(self.url_item('sellers', self.seller_uuid),
                                json.dumps({'name': new_name}),
                                content_type='application/json')
         seller.update({ 'name': new_name })
@@ -102,5 +102,21 @@ class TestItemViews(TestCase):
 
     def test_delete_seller(self):
         self.create_seller()
-        resp = self.client.delete(self.url(self.uuid))
+        resp = self.client.delete(self.url_item('sellers', self.seller_uuid))
         eq_(resp.status_code, 200)
+
+
+class TestProductViews(TestViews):
+
+    def test_create_product(self):
+        seller = self.create_seller()
+        product = {
+            'seller_id': seller['resource_pk'],
+            'external_id': self.product_uuid,
+        }
+        resp = self.client.post(self.url_list('products'), product)
+        product.update({
+            'resource_pk': '1',
+            'resource_uri': '/products/1',
+        })
+        eq_(json.loads(resp.content), product)

--- a/samples/zippy-basic.py
+++ b/samples/zippy-basic.py
@@ -48,6 +48,7 @@ seller = {
 }
 res = client.api.sellers.post(seller)
 print res
+seller_id = res['resource_pk']
 
 print 'Retrieving sellers.'
 res = client.api.sellers.get()
@@ -59,6 +60,15 @@ print res
 
 print 'Updating the created seller.'
 res = client.api.sellers(uid).put({'name': 'Jack'})
+print res
+
+external_id = str(uuid.uuid4())
+print 'Creating seller product with external_id: ' + external_id
+product = {
+    'seller_id': seller_id,
+    'external_id': external_id,
+}
+res = client.api.products.post(product)
 print res
 
 print 'Deleting the created seller.'


### PR DESCRIPTION
Given that you can interact with existing zippy objects without adding a single line of code, the new challenge will be to restrict some actions performed/resources reached by the `zippy.client.Client`.
