### PR TITLE
map request name differently, just because (bug 937701)

### DIFF
--- a/lib/bango/tests/test_client.py
+++ b/lib/bango/tests/test_client.py
@@ -4,7 +4,7 @@ from nose.tools import eq_
 import test_utils
 
 from ..client import (Client, ClientMock, ClientProxy, dict_to_mock,
-                      get_client, response_to_dict)
+                      get_client, get_request, response_to_dict)
 from ..constants import OK, ACCESS_DENIED
 from ..errors import AuthError, BangoError, ProxyError
 
@@ -124,3 +124,9 @@ def test_callable():
     data = {'foo': lambda: 'x'}
     assert callable(dict_to_mock(data).foo)
     assert not callable(dict_to_mock(data, callables=True).foo)
+
+
+def test_request():
+    eq_(get_request('foo'), 'fooRequest')
+    eq_(get_request('CreateBillingConfiguration'),
+        'InnerCreateBillingConfigurationRequest')

--- a/samples/lib.py
+++ b/samples/lib.py
@@ -21,7 +21,7 @@ def call(root, url, method, data):
 
     if result.content:
         print 'Response data:'
-        data = result.json
+        data = result.json() if callable(result.json) else result.json
         pprint.pprint(data)
         print
         return data


### PR DESCRIPTION
also make get_wsdl, so tests can flip between BANGO_ENV easily
and make samples work with either requests
