### PR TITLE
Fix zippy-basic to reflect latest zippy changes (refs 959248)

### DIFF
--- a/samples/zippy-basic.py
+++ b/samples/zippy-basic.py
@@ -44,8 +44,8 @@ res = call('/provider/reference/terms/{0}/'.format(seller_id), 'get', {})
 assert res['text'] == 'Terms for seller: John'
 
 print 'Updating the created seller.'
-res = call('/provider/reference/sellers/{0}/'.format(seller_id), 'put',
-           {'name': 'Jack'})
+seller['name'] = 'Jack'
+res = call('/provider/reference/sellers/{0}/'.format(seller_id), 'put', seller)
 assert res['name'] == 'Jack'
 
 external_id = options.product_id or str(uuid.uuid4())


### PR DESCRIPTION
Given that PATCH isn't accepted anymore for sellers, you have to pass the whole initial object via PUT.
