### PR TITLE
Create a Boku API client in Solitude (bug 992376)

### DIFF
--- a/lib/boku/client.py
+++ b/lib/boku/client.py
@@ -1,0 +1,198 @@
+import calendar
+import hashlib
+import time
+import urllib
+from decimal import Decimal
+from itertools import chain
+
+from django.conf import settings
+
+import lxml
+import requests
+from django_statsd.clients import statsd
+
+from solitude.logger import getLogger
+
+
+log = getLogger('s.boku')
+
+
+def get_boku_request_signature(secret_key, request_args):
+    """
+    Given a dictionary of request parameters, generate
+    an MD5 signature using a secret key.
+
+    Implementation details can be found here:
+    https://merchants.boku.com/white_label/boku
+        /doclibrary/BOKU_SecurityImplementation.pdf
+    """
+    # Sort the pairs by their key name.
+    sorted_pairs = sorted(request_args.items())
+
+    # Combine into a single string with no delimiters.
+    pairs_string = u''.join(map(
+        unicode,
+        chain.from_iterable(sorted_pairs)
+    ))
+
+    # Append the secret key to the end.
+    signature_string = u'{pairs}{secret_key}'.format(
+        pairs=pairs_string,
+        secret_key=secret_key
+    )
+
+    # Run MD5 to get the signature.
+    return hashlib.md5(signature_string.encode('utf8')).hexdigest()
+
+
+class BokuException(Exception):
+
+    def __init__(self, message, result_code=None, result_msg=None):
+        super(BokuException, self).__init__(message)
+        self.result_code = result_code
+        self.result_msg = result_msg
+
+
+class BokuClient(object):
+
+    def __init__(self, merchant_id, secret_key):
+        self.merchant_id = merchant_id
+        self.secret_key = secret_key
+
+    def api_call(self, path, params):
+        if 'timestamp' not in params:
+            params['timestamp'] = str(calendar.timegm(time.gmtime()))
+
+        params['merchant-id'] = self.merchant_id
+        params['sig'] = get_boku_request_signature(self.secret_key, params)
+        url = '{domain}{path}?{params}'.format(
+            domain=settings.BOKU_API_DOMAIN,
+            path=path,
+            params=urllib.urlencode(params)
+        )
+
+        log.info('Boku client call: {url}'.format(url=url))
+        with statsd.timer('solitude.boku.api'):
+            response = requests.get(url)
+
+        # Handle an http request failure.
+        if response.status_code != 200:
+            log.error('Boku API bad status: {url} {status} {content}'.format(
+                url=url,
+                status=response.status_code,
+                content=response.content,
+            ))
+            raise BokuException('Request Failed: {status}'.format(
+                status=response.status_code
+            ))
+
+        # Handle an XML parse failure.
+        try:
+            tree = lxml.etree.fromstring(response.content)
+        except lxml.etree.XMLSyntaxError, exception:
+            log.error('Boku API bad XML: {url} {status} {content}'.format(
+                url=url,
+                status=response.status_code,
+                content=response.content,
+            ))
+            raise BokuException('XML Parse Error: {exception}'.format(
+                exception=exception
+            ))
+
+        # Attempt to find the Boku response code.
+        result_code = tree.find('result-code')
+        if not (result_code is not None and result_code.text.isdigit()):
+            log.error(
+                'Boku API unable to find result code: '
+                '{url} {status} {content}'.format(
+                    url=url,
+                    status=response.status_code,
+                    content=response.content,
+                )
+            )
+            raise BokuException('Unable to determine API call result code')
+
+        # If the result code is non zero, raise an exception.
+        result_code = int(result_code.text)
+        if result_code != 0:
+            result_msg = tree.find('result-msg')
+            if result_msg is not None:
+                result_msg_text = result_msg.text
+            else:
+                result_msg_text = 'Unable to find result message.'
+
+            exception_message = 'API Error: {result_code} {result_msg}'.format(
+                result_code=result_code,
+                result_msg=result_msg_text,
+            )
+            raise BokuException(
+                exception_message,
+                result_code=result_code,
+                result_msg=result_msg_text,
+            )
+
+        return tree
+
+    def get_pricing(self, country, currency=None):
+        """
+        Given a country code and optionally a currency, retrieve the list
+        of supported price points for that country (and currency).
+
+        See Boku Technical documentation for more detail:
+
+        On-Demand Price Points  Request ('price') API Call
+        https://merchants.boku.com/white_label/
+            boku/doclibrary/Boku_Technical_Reference.pdf
+        """
+        params = {
+            'action': 'price',
+            'country': country,
+        }
+
+        if currency:
+            params['currency'] = currency
+
+        tree = self.api_call('/billing/request', params)
+
+        return [pricing.attrib for pricing in tree.findall('pricing')]
+
+    def start_transaction(self, service_id, consumer_id,
+                          price_row, external_id):
+        """
+        Begin a transaction with Boku.
+
+        Parameters:
+
+            service_id - <str> The Boku ID for the service being sold
+            consumer_id - <str> A unique identifier for the purchaser
+            price_row - <int> The price row for a given amount
+                              can be found in get_pricing()
+            external_id - <str> A unique identifier for the transaction
+        """
+        tree = self.api_call('/billing/request', {
+            'action': 'prepare',
+            'param': external_id,
+            'consumer-id': consumer_id,
+            'row-ref': price_row,
+            'service-id': service_id,
+        })
+
+        return {
+            'button_markup': tree.find('button-markup').text,
+            'buy_url': tree.find('buy-url').text,
+            'transaction_id': tree.find('trx-id').text,
+        }
+
+    def check_transaction(self, transaction_id):
+        """
+        Check the status of a transaction_id.
+        """
+        tree = self.api_call('/billing/request', {
+            'action': 'verify-trx-id',
+            'trx-id': transaction_id,
+        })
+
+        return {
+            'amount': Decimal(tree.find('amount').text),
+            'paid': Decimal(tree.find('paid').text),
+        }

--- a/lib/boku/tests/sample_xml.py
+++ b/lib/boku/tests/sample_xml.py
@@ -1,0 +1,63 @@
+empty = \
+    """<?xml version='1.0' encoding='UTF-8' ?>
+    <billing-request>
+    </billing-request>"""
+
+billing_request = \
+    """<?xml version='1.0' encoding='UTF-8' ?>
+    <billing-request>
+      <result-code>{result_code}</result-code>
+      <result-msg>{result_message}</result-msg>
+    </billing-request>"""
+
+pricing_request = \
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <pricing>
+      <timestamp string="2014-04-08 15:58:25">1396972705026</timestamp>
+      <action>price</action>
+      <result-code>0</result-code>
+      <result-msg>Operation Successful</result-msg>
+      <reference-currency>USD</reference-currency>
+      <pricing
+        country="CA"
+        amount="1500"
+        currency="CDN"
+        currency-symbol="$"
+        currency-symbol-orientation="l"
+        currency-decimal-places="2"
+        price-inc-salestax="1500"
+        price-ex-salestax="1293"
+        receivable-gross="465"
+        receivable-net="419"
+        exchange="13.01193"
+        reference-amount="115"
+        reference-price-inc-salestax="115"
+        reference-price-ex-salestax="99"
+        reference-receivable-gross="36"
+        reference-receivable-net="32"
+        number-billed-messages="1"
+        status="1" display-price="$15.00"
+      />
+    </pricing>"""
+
+prepare_request = \
+    """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <prepare-request>
+      <action>prepare</action>
+      <trx-id>{transaction_id}</trx-id>
+      <result-code>0</result-code>
+      <result-msg>Operation Successful</result-msg>
+      <button-markup>example_markup</button-markup>
+      <buy-url>http://example_buy_url/</buy-url>
+    </prepare-request>"""
+
+transaction_request = \
+    """<?xml version="1.0" encoding="ISO-8859-1" ?>
+    <billing-request>
+      <action>verify-trx-id</action>
+      <trx-id>{transaction_id}</trx-id>
+      <result-code>0</result-code>
+      <result-msg>Operation Successful</result-msg>
+      <amount>100</amount>
+      <paid>100</paid>
+    </billing-request>"""

--- a/lib/boku/tests/test_client.py
+++ b/lib/boku/tests/test_client.py
@@ -1,0 +1,228 @@
+import time
+
+import mock
+import test_utils
+from nose.tools import assert_raises, eq_, ok_
+
+from lib.boku.client import (get_boku_request_signature,
+                             BokuClient, BokuException)
+from lib.boku.tests import sample_xml
+
+
+class BokuClientTests(test_utils.TestCase):
+
+    def setUp(self):
+        self.merchant_id = 'merchant_id'
+        self.secret_key = 'secret_key'
+        self.client = BokuClient(self.merchant_id, self.secret_key)
+        self.patched_get = mock.patch('requests.get')
+        self.mock_get = self.patched_get.start()
+        self.addCleanup(self.patched_get.stop)
+
+    def test_client_uses_signed_request(self):
+        params = {
+            'merchant-id': self.merchant_id,
+            'param': 'value',
+            'timestamp': int(time.time()),
+        }
+        signature = get_boku_request_signature(self.secret_key, params)
+
+        try:
+            self.client.api_call('/path', params)
+        except:
+            pass
+
+        call_url = self.mock_get.call_args[0][0]
+        sig_param = 'sig={signature}'.format(signature=signature)
+        ok_(sig_param in call_url)
+
+    def test_client_raises_exception_on_non_200_http_response(self):
+        response = mock.Mock()
+        response.status_code = 400
+        self.mock_get.return_value = response
+
+        with assert_raises(BokuException) as context:
+            self.client.api_call('/path', {})
+
+        eq_(context.exception.message, 'Request Failed: 400')
+
+    def test_client_raises_exception_on_invalid_xml(self):
+        response = mock.Mock()
+        response.status_code = 200
+        response.content = '<invalid xml'
+        self.mock_get.return_value = response
+
+        with assert_raises(BokuException) as context:
+            self.client.api_call('/path', {})
+
+        ok_(
+            'XML Parse Error' in context.exception.message,
+            'XML Parse Error not found in {message}'.format(
+                message=context.exception.message
+            )
+        )
+
+    def test_client_raises_exception_when_response_code_not_present(self):
+        response = mock.Mock()
+        response.status_code = 200
+        response.content = sample_xml.empty
+        self.mock_get.return_value = response
+
+        with assert_raises(BokuException) as context:
+            self.client.api_call('/path', {})
+
+        eq_(
+            context.exception.message,
+            'Unable to determine API call result code'
+        )
+
+    def test_client_raises_exception_on_non_zero_response_code(self):
+        result_code = 1
+        result_message = 'Failure!'
+
+        response = mock.Mock()
+        response.status_code = 200
+        response.content = sample_xml.billing_request.format(
+            result_code=result_code,
+            result_message=result_message
+        )
+        self.mock_get.return_value = response
+
+        with assert_raises(BokuException) as context:
+            self.client.api_call('/path', {})
+
+        eq_(
+            context.exception.message,
+            'API Error: {result_code} {result_message}'.format(
+                result_code=result_code,
+                result_message=result_message
+            )
+        )
+        eq_(context.exception.result_code, result_code)
+        eq_(context.exception.result_msg, result_message)
+
+    def test_client_get_pricing_calls_api_with_correct_params(self):
+        country = 'CA'
+
+        with mock.patch('lib.boku.client.BokuClient.api_call') as MockClient:
+            try:
+                self.client.get_pricing(country)
+            except BokuException:
+                pass
+
+            MockClient.assert_called_with('/billing/request', {
+                'action': 'price',
+                'country': country,
+            })
+
+    def test_client_get_pricing_calls_returns_pricing_json(self):
+        response = mock.Mock()
+        response.status_code = 200
+        response.content = sample_xml.pricing_request
+        self.mock_get.return_value = response
+
+        prices = self.client.get_pricing('CA', currency='CDN')
+        eq_(
+            prices, [{
+                'status': '1',
+                'receivable-gross': '465',
+                'currency-decimal-places': '2',
+                'reference-amount': '115',
+                'exchange': '13.01193',
+                'currency-symbol-orientation': 'l',
+                'country': 'CA',
+                'display-price': '$15.00',
+                'reference-receivable-gross': '36',
+                'reference-receivable-net': '32',
+                'price-ex-salestax': '1293',
+                'currency': 'CDN',
+                'amount': '1500',
+                'reference-price-inc-salestax': '115',
+                'currency-symbol': '$',
+                'price-inc-salestax': '1500',
+                'reference-price-ex-salestax': '99',
+                'receivable-net': '419',
+                'number-billed-messages': '1'
+            }]
+        )
+
+    def test_client_start_transaction_calls_api_with_correct_params(self):
+        service_id = 'service id'
+        consumer_id = 'consumer'
+        price_row = 1
+        external_id = 'external id'
+
+        with mock.patch('lib.boku.client.BokuClient.api_call') as MockClient:
+            try:
+                self.client.start_transaction(
+                    service_id,
+                    consumer_id,
+                    price_row,
+                    external_id=external_id
+                )
+            except BokuException:
+                pass
+
+            MockClient.assert_called_with('/billing/request', {
+                'action': 'prepare',
+                'consumer-id': 'consumer',
+                'row-ref': 1,
+                'param': 'external id',
+                'service-id': 'service id',
+            })
+
+    def test_client_start_transaction_returns_start_transaction_json(self):
+        service_id = 'service id'
+        consumer_id = 'consumer'
+        price_row = 1
+        external_id = 'external id'
+        transaction_id = 'abc123'
+
+        response = mock.Mock()
+        response.status_code = 200
+        response.content = sample_xml.prepare_request.format(
+            transaction_id=transaction_id
+        )
+        self.mock_get.return_value = response
+
+        transaction = self.client.start_transaction(
+            service_id,
+            consumer_id,
+            price_row,
+            external_id=external_id
+        )
+        eq_(
+            transaction, {
+                'buy_url': 'http://example_buy_url/',
+                'transaction_id': transaction_id,
+                'button_markup': 'example_markup',
+            }
+        )
+
+    def test_client_check_transaction_calls_api_with_correct_params(self):
+        transaction_id = 'abc123'
+
+        with mock.patch('lib.boku.client.BokuClient.api_call') as MockClient:
+            try:
+                self.client.check_transaction(transaction_id)
+            except Exception:
+                pass
+
+            MockClient.assert_called_with('/billing/request', {
+                'action': 'verify-trx-id',
+                'trx-id': transaction_id,
+            })
+
+    def test_client_check_transaction_returns_check_transaction_json(self):
+        transaction_id = 'abc123'
+        amount = 100
+
+        response = mock.Mock()
+        response.status_code = 200
+        response.content = sample_xml.transaction_request.format(
+            transaction_id=transaction_id
+        )
+        self.mock_get.return_value = response
+
+        transaction = self.client.check_transaction(transaction_id)
+        eq_(transaction, {'amount': amount, 'paid': amount})


### PR DESCRIPTION
- Create an MD5 signer for request signatures
- Parse XML content returned
- Create wrapper methods for interacting with commonly used endpoints
  - Get pricing tiers
  - Start a transaction
  - Check the status of a transaction
