### PR TITLE
Implement a start transaction API endpoint in Solitude (bug 987836)

### DIFF
--- a/lib/boku/constants.py
+++ b/lib/boku/constants.py
@@ -10,3 +10,7 @@ CURRENCIES = {
 DECIMAL_PLACES = {
     'MXN': 100,
 }
+
+COUNTRY_CHOICES = (
+    ('MX', 'MX'),
+)

--- a/lib/boku/tests/test_client.py
+++ b/lib/boku/tests/test_client.py
@@ -151,24 +151,27 @@ class BokuClientTests(test_utils.TestCase):
         consumer_id = 'consumer'
         price_row = 1
         external_id = 'external id'
+        callback_url = 'http://test/'
 
         with mock.patch('lib.boku.client.BokuClient.api_call') as MockClient:
             try:
                 self.client.start_transaction(
-                    service_id,
-                    consumer_id,
-                    price_row,
-                    external_id=external_id
+                    callback_url=callback_url,
+                    consumer_id=consumer_id,
+                    external_id=external_id,
+                    price_row=price_row,
+                    service_id=service_id,
                 )
             except BokuException:
                 pass
 
             MockClient.assert_called_with('/billing/request', {
                 'action': 'prepare',
-                'consumer-id': 'consumer',
-                'row-ref': 1,
-                'param': 'external id',
-                'service-id': 'service id',
+                'callback-url': callback_url,
+                'consumer-id': consumer_id,
+                'param': external_id,
+                'row-ref': price_row,
+                'service-id': service_id,
             })
 
     def test_client_start_transaction_returns_start_transaction_json(self):
@@ -176,6 +179,7 @@ class BokuClientTests(test_utils.TestCase):
         consumer_id = 'consumer'
         price_row = 1
         external_id = 'external id'
+        callback_url = 'http://test/'
         transaction_id = 'abc123'
 
         response = mock.Mock()
@@ -186,16 +190,16 @@ class BokuClientTests(test_utils.TestCase):
         self.mock_get.return_value = response
 
         transaction = self.client.start_transaction(
-            service_id,
-            consumer_id,
-            price_row,
-            external_id=external_id
+            callback_url=callback_url,
+            consumer_id=consumer_id,
+            external_id=external_id,
+            price_row=price_row,
+            service_id=service_id,
         )
         eq_(
             transaction, {
                 'buy_url': 'http://example_buy_url/',
                 'transaction_id': transaction_id,
-                'button_markup': 'example_markup',
             }
         )
 

--- a/lib/boku/tests/test_forms.py
+++ b/lib/boku/tests/test_forms.py
@@ -1,8 +1,10 @@
-from nose.tools import eq_, ok_
+import mock
+from nose.tools import assert_raises, eq_, ok_
 from test_utils import TestCase
 
-from lib.boku.forms import BokuForm, EventForm
-from lib.boku.tests.utils import EventTest
+from lib.boku.errors import BokuException
+from lib.boku.forms import BokuForm, BokuTransactionForm, EventForm
+from lib.boku.tests.utils import BokuTransactionTest, EventTest
 from lib.transactions.constants import PROVIDER_BANGO, STATUS_COMPLETED
 
 
@@ -40,3 +42,61 @@ class TestForm(EventTest):
         self.trans.status = STATUS_COMPLETED
         self.trans.save()
         ok_(not EventForm(self.sample()).is_valid())
+
+
+class BokuTransactionFormTests(BokuTransactionTest):
+
+    def test_callback_url_requires_a_valid_url(self):
+        self.post_data['callback_url'] = 'foo'
+        form = BokuTransactionForm(self.post_data)
+        ok_(not form.is_valid(), form.errors)
+        ok_('callback_url' in form.errors, form.errors)
+
+    def test_country_requires_a_defined_country_code(self):
+        self.post_data['country'] = 'foo'
+        form = BokuTransactionForm(self.post_data)
+        ok_(not form.is_valid(), form.errors)
+        ok_('country' in form.errors)
+
+    def test_price_requires_a_decimal_value(self):
+        self.post_data['price'] = 'foo'
+        form = BokuTransactionForm(self.post_data)
+        ok_(not form.is_valid(), form.errors)
+        ok_('price' in form.errors)
+
+    def test_price_requires_an_existing_boku_price_tier(self):
+        self.post_data['price'] = '1.00'
+        form = BokuTransactionForm(self.post_data)
+        ok_(not form.is_valid(), form.errors)
+        ok_(form.ERROR_BAD_PRICE in form.errors['__all__'])
+
+    def test_seller_uuid_requires_an_existing_seller(self):
+        self.post_data['seller_uuid'] = 'foo'
+        form = BokuTransactionForm(self.post_data)
+        ok_(not form.is_valid(), form.errors)
+        ok_('seller_uuid' in form.errors)
+
+    def test_seller_uuid_requires_a_boku_seller(self):
+        self.seller_boku.delete()
+        form = BokuTransactionForm(self.post_data)
+        ok_(not form.is_valid(), form.errors)
+        ok_('seller_uuid' in form.errors)
+
+    def test_starting_a_transaction_before_validation_fails(self):
+        form = BokuTransactionForm(self.post_data)
+        assert_raises(Exception, form.start_transaction)
+
+    def test_boku_failure_raises_BokuException(self):
+        form = BokuTransactionForm(self.post_data)
+        ok_(form.is_valid(), form.errors)
+
+        with mock.patch('lib.boku.client.mocks', {'prepare': (500, '')}):
+            assert_raises(BokuException, form.start_transaction)
+
+    def test_start_boku_transaction_with_valid_data(self):
+        form = BokuTransactionForm(self.post_data)
+        ok_(form.is_valid(), form.errors)
+
+        transaction = form.start_transaction()
+        ok_('transaction_id' in transaction, transaction)
+        ok_('buy_url' in transaction, transaction)

--- a/lib/boku/tests/test_utils_.py
+++ b/lib/boku/tests/test_utils_.py
@@ -15,11 +15,11 @@ class TestFixPrice(TestCase):
         eq_(fix_price(Decimal('100'), 'MXN'), Decimal('1.00'))
 
     @raises(KeyError)
-    def test_other(self):
+    def test_bad_currency_name_raises_keyerror(self):
         eq_(fix_price(Decimal('100'), 'FOO'))
 
     @raises(AssertionError)
-    def test_other(self):
+    def test_decimal_required_for_value(self):
         eq_(fix_price(100.0, 'MXN'))
 
 

--- a/lib/boku/tests/test_views.py
+++ b/lib/boku/tests/test_views.py
@@ -5,7 +5,7 @@ from django.core.urlresolvers import reverse
 
 from nose.tools import eq_, ok_
 
-from lib.boku.tests.utils import SellerBokuTest
+from lib.boku.tests.utils import BokuTransactionTest, SellerBokuTest
 from lib.sellers.models import Seller, SellerBoku
 
 
@@ -89,3 +89,25 @@ class TestSellerBokuViews(SellerBokuTest):
             reverse('boku:sellerboku-detail', kwargs={'pk': seller_boku.pk})
         )
         eq_(response.status_code, 403, response.content)
+
+
+class TestBokuTransactionView(BokuTransactionTest):
+
+    def setUp(self):
+        super(TestBokuTransactionView, self).setUp()
+        self.url = reverse('boku:start_transaction')
+
+    def test_valid_data_starts_transaction(self):
+        response = self.client.post(self.url, data=self.post_data)
+        eq_(response.status_code, 200, response.content)
+
+        transaction_data = json.loads(response.content)
+        ok_('transaction_id' in transaction_data)
+
+    def test_invalid_data_returns_form_errors(self):
+        self.post_data['callback_url'] = 'foo'
+        response = self.client.post(self.url, data=self.post_data)
+        eq_(response.status_code, 400, response.content)
+
+        transaction_data = json.loads(response.content)
+        eq_(transaction_data['callback_url'], ['Enter a valid URL.'])

--- a/lib/boku/tests/utils.py
+++ b/lib/boku/tests/utils.py
@@ -2,6 +2,9 @@ import uuid
 
 from django.core.urlresolvers import reverse
 
+import test_utils
+
+from lib.boku import constants
 from lib.sellers.models import Seller, SellerBoku, SellerProduct
 from lib.transactions.constants import PROVIDER_BOKU
 from lib.transactions.models import Transaction
@@ -53,4 +56,28 @@ class EventTest(SellerBokuTest):
             'param': 'some:uuid',
             'sig': 'some:sig',
             'trx-id': 'some:trxid'
+        }
+
+
+class BokuTransactionTest(test_utils.TestCase):
+
+    def setUp(self):
+        self.transaction_uuid = str(uuid.uuid4())
+        self.seller_uuid = str(uuid.uuid4())
+        self.user_uuid = str(uuid.uuid4())
+
+        self.seller = Seller.objects.create(uuid=self.seller_uuid)
+        self.seller_boku = SellerBoku.objects.create(
+            seller=self.seller,
+            merchant_id='merchant_id',
+            service_id='service_id'
+        )
+
+        self.post_data = {
+            'callback_url': 'http://testing.com/callback/',
+            'country': constants.COUNTRY_CHOICES[0][0],
+            'transaction_uuid': self.transaction_uuid,
+            'price': '15.00',
+            'seller_uuid': self.seller_uuid,
+            'user_uuid': self.user_uuid,
         }

--- a/lib/boku/urls.py
+++ b/lib/boku/urls.py
@@ -1,8 +1,17 @@
+from django.conf.urls import url
+
 from rest_framework.routers import DefaultRouter
 
-from .views import SellerBokuViewSet
+from lib.boku.views import SellerBokuViewSet, BokuTransactionView
 
 router = DefaultRouter()
 router.register(r'seller', SellerBokuViewSet)
 
 urlpatterns = router.urls
+urlpatterns += [
+    url(
+        r'transaction',
+        BokuTransactionView.as_view(),
+        name='start_transaction'
+    ),
+]

--- a/lib/boku/views.py
+++ b/lib/boku/views.py
@@ -1,8 +1,15 @@
 from rest_framework import viewsets
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.response import Response
 
-from .serializers import SellerBokuSerializer
+from lib.boku.forms import BokuTransactionForm
+from lib.boku.serializers import SellerBokuSerializer
 from lib.sellers.models import SellerBoku
+from solitude.base import BaseAPIView
+from solitude.logger import getLogger
+
+
+log = getLogger('s.boku')
 
 
 class SellerBokuViewSet(viewsets.ModelViewSet):
@@ -11,3 +18,22 @@ class SellerBokuViewSet(viewsets.ModelViewSet):
 
     def destroy(self, request, pk=None):
         raise PermissionDenied
+
+
+class BokuTransactionView(BaseAPIView):
+
+    def post(self, request):
+        form = BokuTransactionForm(request.POST)
+
+        if form.is_valid():
+            transaction = form.start_transaction()
+            log.error(('Successfully started Boku Transaction: '
+                       '{transaction_id}').format(
+                transaction_id=transaction['transaction_id'],
+            ))
+            return Response(transaction)
+        else:
+            log.error('Failed to start Boku Transaction: {errors}'.format(
+                errors=form.errors,
+            ))
+            return self.form_errors(form)


### PR DESCRIPTION
- Create a Boku Transaction Form that wraps the start transaction endpoint in the Boku client
- Create an API View which wraps the form
- Add form and view tests as necessary
