### PR TITLE
Create a SellerProductBoku model/API (bug 998045)

### DIFF
--- a/lib/boku/serializers.py
+++ b/lib/boku/serializers.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
 
 from solitude.base import CompatRelatedField
-from lib.sellers.models import Seller, SellerBoku
+from lib.sellers.models import (Seller, SellerBoku,
+                                SellerProduct, SellerProductBoku)
 
 
 class SellerBokuSerializer(serializers.ModelSerializer):
@@ -21,3 +22,27 @@ class SellerBokuSerializer(serializers.ModelSerializer):
     class Meta:
         model = SellerBoku
         fields = ('id', 'seller', 'service_id', 'resource_uri')
+
+
+class SellerProductBokuSerializer(serializers.ModelSerializer):
+    seller_product = CompatRelatedField(
+        source='seller_product',
+        tastypie={
+            'resource_name': 'product',
+            'api_name': 'generic'
+        },
+        view_name='api_dispatch_detail',
+        queryset=SellerProduct.objects.filter()
+    )
+    seller_boku = serializers.HyperlinkedRelatedField(
+        many=False,
+        read_only=False,
+        view_name='boku:sellerboku-detail',
+    )
+    resource_uri = serializers.HyperlinkedIdentityField(
+        view_name='boku:sellerproductboku-detail'
+    )
+
+    class Meta:
+        model = SellerProductBoku
+        fields = ('id', 'seller_product', 'seller_boku', 'resource_uri')

--- a/lib/boku/tests/test_client.py
+++ b/lib/boku/tests/test_client.py
@@ -118,13 +118,13 @@ class BokuClientTests(test_utils.TestCase):
     def test_client_get_pricing_calls_api_with_correct_params(self):
         country = 'CA'
 
-        with mock.patch('lib.boku.client.BokuClient.api_call') as MockClient:
+        with mock.patch('lib.boku.client.BokuClient.api_call') as mock_client:
             try:
                 self.client.get_pricing(country)
             except BokuException:
                 pass
 
-            MockClient.assert_called_with('/billing/request', {
+            mock_client.assert_called_with('/billing/request', {
                 'action': 'price',
                 'country': country,
             })
@@ -168,7 +168,7 @@ class BokuClientTests(test_utils.TestCase):
         callback_url = 'http://test/'
         forward_url = 'http://test/success'
 
-        with mock.patch('lib.boku.client.BokuClient.api_call') as MockClient:
+        with mock.patch('lib.boku.client.BokuClient.api_call') as mock_client:
             try:
                 self.start_transaction(
                     callback_url=callback_url,
@@ -181,7 +181,7 @@ class BokuClientTests(test_utils.TestCase):
             except BokuException:
                 pass
 
-            MockClient.assert_called_with('/billing/request', {
+            mock_client.assert_called_with('/billing/request', {
                 'action': 'prepare',
                 'callback-url': callback_url,
                 'fwdurl': forward_url,
@@ -211,13 +211,13 @@ class BokuClientTests(test_utils.TestCase):
     def test_client_check_transaction_calls_api_with_correct_params(self):
         transaction_id = 'abc123'
 
-        with mock.patch('lib.boku.client.BokuClient.api_call') as MockClient:
+        with mock.patch('lib.boku.client.BokuClient.api_call') as mock_client:
             try:
                 self.client.check_transaction(transaction_id)
             except Exception:
                 pass
 
-            MockClient.assert_called_with('/billing/request', {
+            mock_client.assert_called_with('/billing/request', {
                 'action': 'verify-trx-id',
                 'trx-id': transaction_id,
             })

--- a/lib/boku/tests/test_serializers.py
+++ b/lib/boku/tests/test_serializers.py
@@ -1,9 +1,9 @@
 from django.core.urlresolvers import reverse
 from nose.tools import eq_
 
-from ..serializers import SellerBokuSerializer
-from .utils import SellerBokuTest
-from lib.sellers.models import SellerBoku
+from ..serializers import SellerBokuSerializer, SellerProductBokuSerializer
+from .utils import SellerBokuTest, SellerProductBokuTest
+from lib.sellers.models import SellerBoku, SellerProductBoku
 
 
 class SellerBokuSerializerTests(SellerBokuTest):
@@ -40,3 +40,44 @@ class SellerBokuSerializerTests(SellerBokuTest):
         eq_(serializer.data['service_id'], seller_boku.service_id)
         eq_(serializer.data['resource_uri'],
             reverse('boku:sellerboku-detail', kwargs={'pk': seller_boku.pk}))
+
+
+class SellerProductBokuSerializerTests(SellerProductBokuTest):
+
+    def test_seller_boku_required(self):
+        del self.seller_product_boku_data['seller_boku']
+
+        serializer = SellerProductBokuSerializer(
+            data=self.seller_product_boku_data)
+        eq_(serializer.is_valid(), False)
+
+    def test_seller_product_required(self):
+        del self.seller_product_boku_data['seller_product']
+
+        serializer = SellerProductBokuSerializer(
+            data=self.seller_product_boku_data)
+        eq_(serializer.is_valid(), False)
+
+    def test_valid_data_creates_new_seller_product_boku(self):
+        serializer = SellerProductBokuSerializer(
+            data=self.seller_product_boku_data)
+        eq_(serializer.is_valid(), True)
+        serializer.save()
+        seller_product_boku = SellerProductBoku.objects.get(
+            pk=serializer.object.pk)
+        eq_(seller_product_boku.seller_product, self.seller_product)
+        eq_(seller_product_boku.seller_boku, self.seller_boku)
+
+    def test_serializer_outputs_correct_data(self):
+        seller_product_boku = SellerProductBoku.objects.create(
+            seller_product=self.seller_product,
+            seller_boku=self.seller_boku,
+        )
+
+        serializer = SellerProductBokuSerializer(seller_product_boku)
+        eq_(serializer.data['id'], seller_product_boku.pk)
+        eq_(serializer.data['seller_product'], self.seller_product_uri)
+        eq_(serializer.data['seller_boku'], self.seller_boku_uri)
+        eq_(serializer.data['resource_uri'],
+            reverse('boku:sellerproductboku-detail',
+                    kwargs={'pk': seller_product_boku.pk}))

--- a/lib/boku/tests/utils.py
+++ b/lib/boku/tests/utils.py
@@ -31,6 +31,39 @@ class SellerBokuTest(APITest):
         }
 
 
+class SellerProductBokuTest(SellerBokuTest):
+
+    def setUp(self):
+        super(SellerProductBokuTest, self).setUp()
+        self.seller_product = SellerProduct.objects.create(
+            seller=self.seller,
+            public_id=str(uuid.uuid4()),
+            external_id=str(uuid.uuid4()),
+        )
+        self.seller_boku = SellerBoku.objects.create(
+            seller=self.seller,
+            service_id='abc',
+        )
+
+        self.seller_product_uri = reverse(
+            'api_dispatch_detail',
+            kwargs={
+                'api_name': 'generic',
+                'resource_name': 'product',
+                'pk': self.seller_product.pk,
+            }
+        )
+        self.seller_boku_uri = reverse(
+            'boku:sellerboku-detail',
+            args=(self.seller_boku.pk,)
+        )
+
+        self.seller_product_boku_data = {
+            'seller_product': self.seller_product_uri,
+            'seller_boku': self.seller_boku_uri,
+        }
+
+
 class EventTest(SellerBokuTest):
 
     def setUp(self):

--- a/lib/boku/urls.py
+++ b/lib/boku/urls.py
@@ -2,11 +2,12 @@ from django.conf.urls import url
 
 from rest_framework.routers import DefaultRouter
 
-from lib.boku.views import (SellerBokuViewSet, BokuTransactionView,
-                            BokuVerifyServiceView)
+from lib.boku.views import (SellerBokuViewSet, SellerProductBokuViewSet,
+                            BokuTransactionView, BokuVerifyServiceView)
 
 router = DefaultRouter()
 router.register(r'seller', SellerBokuViewSet)
+router.register(r'product', SellerProductBokuViewSet)
 
 urlpatterns = router.urls
 urlpatterns += [

--- a/lib/boku/views.py
+++ b/lib/boku/views.py
@@ -3,8 +3,9 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from lib.boku.forms import BokuTransactionForm, BokuServiceForm
-from lib.boku.serializers import SellerBokuSerializer
-from lib.sellers.models import SellerBoku
+from lib.boku.serializers import (SellerBokuSerializer,
+                                  SellerProductBokuSerializer)
+from lib.sellers.models import SellerBoku, SellerProductBoku
 from solitude.base import BaseAPIView
 from solitude.logger import getLogger
 
@@ -15,6 +16,14 @@ log = getLogger('s.boku')
 class SellerBokuViewSet(viewsets.ModelViewSet):
     model = SellerBoku
     serializer_class = SellerBokuSerializer
+
+    def destroy(self, request, pk=None):
+        raise PermissionDenied
+
+
+class SellerProductBokuViewSet(viewsets.ModelViewSet):
+    model = SellerProductBoku
+    serializer_class = SellerProductBokuSerializer
 
     def destroy(self, request, pk=None):
         raise PermissionDenied

--- a/lib/sellers/models.py
+++ b/lib/sellers/models.py
@@ -104,3 +104,12 @@ class SellerBoku(Model):
 
     class Meta(Model.Meta):
         db_table = 'seller_boku'
+
+
+class SellerProductBoku(Model):
+    seller_product = models.OneToOneField(SellerProduct,
+                                          related_name='product_boku')
+    seller_boku = models.ForeignKey(SellerBoku, related_name='product_boku')
+
+    class Meta(Model.Meta):
+        db_table = 'seller_product_boku'

--- a/migrations/44-add-product-boku.sql
+++ b/migrations/44-add-product-boku.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `seller_product_boku` (
+    `id` int(11) unsigned AUTO_INCREMENT NOT NULL PRIMARY KEY,
+    `created` datetime NOT NULL,
+    `modified` datetime NOT NULL,
+    `counter` bigint,
+    `seller_product_id` int(11) unsigned NOT NULL UNIQUE,
+    `seller_boku_id` int(11) unsigned NOT NULL UNIQUE
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+ALTER TABLE `seller_product_boku` ADD CONSTRAINT `seller_product_id_refs_id_boku`
+    FOREIGN KEY (`seller_product_id`) REFERENCES `seller_product` (`id`);
+ALTER TABLE `seller_product_boku` ADD CONSTRAINT `seller_boku_id_refs_id_boku`
+    FOREIGN KEY (`seller_boku_id`) REFERENCES `seller_boku` (`id`);


### PR DESCRIPTION
- Create a SellerProductBoku model
- Add a migration
- Create an API with serializer, viewset
- Add tests
