### PR TITLE
Send buyer's country to Boku (bug 1004207)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,8 +17,9 @@ every API that the provider supports.
 Currently we support:
 
 * some `PayPal <https://www.paypal.com/>`_ APIs
-* some `Bango <http://bango.com/>`_ support
-* some `Zippy <http://zippypayments.readthedocs.org/>`_ support
+* some `Bango <http://bango.com/>`_ APIs
+* some `Boku <http://www.boku.com/>`_ APIs
+* some `Zippy <http://zippypayments.readthedocs.org/>`_ compliance
 
 This project is based on **playdoh**. Mozilla's Playdoh is an open source
 web application template based on `Django <http://www.djangoproject.com/>`_.

--- a/docs/topics/boku.rst
+++ b/docs/topics/boku.rst
@@ -42,7 +42,7 @@ Start a transaction with Boku.
                          complete.
     :param forward_url: A URL that Boku redirects the client to
                         after successful/failed payment.
-    :param country: The country code of the purchaser.
+    :param country: The `ISO 3166-1-alpha-2`_ country code of the purchaser.
     :param transaction_uuid: A unique identifier to track the transaction.
     :param price: The purchase price in Decimal format (2 decimal places).
                   It must match one of the existing price points in Boku.
@@ -72,6 +72,8 @@ Start a transaction with Boku.
 
     :status 200: successfully processed.
     :status 400: problem with the data.
+
+.. _`ISO 3166-1-alpha-2`: http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 
 Event
 =====

--- a/lib/boku/client.py
+++ b/lib/boku/client.py
@@ -204,7 +204,7 @@ class BokuClient(object):
 
     def start_transaction(self, callback_url, consumer_id,
                           external_id, price_row, service_id,
-                          forward_url):
+                          forward_url, country):
         """
         Begin a transaction with Boku.
 
@@ -219,6 +219,8 @@ class BokuClient(object):
         :param price_row: The price row (integer) for a given amount
                           can be found in get_pricing().
         :param service_id: The Boku ID (integer) for the service being sold.
+        :param country: The ISO 3166-1-alpha-2 country code that they
+                        buyer is in.
         """
         tree = self.api_call('/billing/request', {
             'action': 'prepare',
@@ -228,6 +230,7 @@ class BokuClient(object):
             'param': external_id,
             'row-ref': price_row,
             'service-id': service_id,
+            'country': country,
         })
 
         return {

--- a/lib/boku/constants.py
+++ b/lib/boku/constants.py
@@ -11,6 +11,7 @@ DECIMAL_PLACES = {
     'MXN': 100,
 }
 
+# Boku country choices as specified in ISO 3166-1-alpha-2.
 COUNTRY_CHOICES = (
     ('MX', 'MX'),
 )

--- a/lib/boku/forms.py
+++ b/lib/boku/forms.py
@@ -142,6 +142,7 @@ class BokuTransactionForm(BokuClientMixin, forms.Form):
             consumer_id=self.cleaned_data['user_uuid'],
             price_row=self.cleaned_data['price_row'],
             service_id=self.cleaned_data['seller_uuid'].boku.service_id,
+            country=self.cleaned_data['country'],
         )
 
 

--- a/lib/boku/tests/test_client.py
+++ b/lib/boku/tests/test_client.py
@@ -25,13 +25,15 @@ class BokuClientTests(test_utils.TestCase):
                           consumer_id='consumer', price_row=1,
                           external_id='external id',
                           callback_url='http://test/',
-                          forward_url='http://test/success'):
+                          forward_url='http://test/success',
+                          country='MX'):
         return self.client.start_transaction(service_id=service_id,
                                              consumer_id=consumer_id,
                                              price_row=price_row,
                                              external_id=external_id,
                                              callback_url=callback_url,
-                                             forward_url=forward_url)
+                                             forward_url=forward_url,
+                                             country=country)
 
     def test_client_uses_signed_request(self):
         params = {
@@ -167,6 +169,7 @@ class BokuClientTests(test_utils.TestCase):
         external_id = 'external id'
         callback_url = 'http://test/'
         forward_url = 'http://test/success'
+        country = 'MX'
 
         with mock.patch('lib.boku.client.BokuClient.api_call') as mock_client:
             try:
@@ -177,6 +180,7 @@ class BokuClientTests(test_utils.TestCase):
                     external_id=external_id,
                     price_row=price_row,
                     service_id=service_id,
+                    country=country,
                 )
             except BokuException:
                 pass
@@ -189,6 +193,7 @@ class BokuClientTests(test_utils.TestCase):
                 'param': external_id,
                 'row-ref': price_row,
                 'service-id': service_id,
+                'country': country,
             })
 
     def test_client_start_transaction_returns_start_transaction_json(self):

--- a/lib/boku/tests/utils.py
+++ b/lib/boku/tests/utils.py
@@ -105,7 +105,7 @@ class BokuTransactionTest(test_utils.TestCase):
         self.post_data = {
             'callback_url': 'http://testing.com/pay/notification',
             'forward_url': 'http://testing.com/pay/success',
-            'country': constants.COUNTRY_CHOICES[0][0],
+            'country': constants.COUNTRY_CHOICES[0][0],  # MX
             'transaction_uuid': self.transaction_uuid,
             'price': '15.00',
             'seller_uuid': self.seller_uuid,


### PR DESCRIPTION
I think this was an oversight in the original
patch. It also makes the user experience nicer
since otherwise they have to select a country
before starting the payment.
