### PR TITLE
Fix how the proxy adds a signature for Boku

### DIFF
--- a/lib/proxy/tests.py
+++ b/lib/proxy/tests.py
@@ -60,7 +60,8 @@ class TestPaypal(Proxy):
     def test_result(self):
         self.req.post.side_effect = self.req.exceptions.RequestException()
         with self.settings(DEBUG=False):
-            res = self.client.post(self.url, **{HEADERS_URL_GET: 'get-pay-key'})
+            res = self.client.post(self.url,
+                                   **{HEADERS_URL_GET: 'get-pay-key'})
             eq_(res.status_code, 500)
 
     def test_not_enabled(self):
@@ -116,19 +117,9 @@ class TestBango(Proxy):
 
 
 @mock.patch.object(settings, 'SOLITUDE_PROXY', True)
-class TestBoku(Proxy):
-
-    def setUp(self):
-        super(TestBoku, self).setUp()
-        self.url = reverse('boku.proxy')
-
-    def test_not_implemented(self):
-        self.client.post(self.url, {})
-
-
-@mock.patch.object(settings, 'SOLITUDE_PROXY', True)
-@mock.patch.object(settings, 'ZIPPY_CONFIGURATION', {'f':
-    {'url': 'http://f.c', 'auth': {'key': 'k', 'secret': 's'}}})
+@mock.patch.object(
+    settings, 'ZIPPY_CONFIGURATION',
+    {'f': {'url': 'http://f.c', 'auth': {'key': 'k', 'secret': 's'}}})
 class TestProvider(Proxy):
 
     def setUp(self):
@@ -162,17 +153,18 @@ class TestProvider(Proxy):
 
 
 @mock.patch.object(settings, 'SOLITUDE_PROXY', True)
-@mock.patch.object(settings, 'ZIPPY_CONFIGURATION',
+@mock.patch.object(
+    settings, 'ZIPPY_CONFIGURATION',
     {'boku': {'url': 'http://f.c', 'auth': {'secret': 's', 'key': 'f'}}})
 class TestBoku(Proxy):
 
     def setUp(self):
         super(TestBoku, self).setUp()
         self.url = reverse('provider.proxy', kwargs={'reference_name': 'boku'})
-        self.url = self.url + '/billing/request?f=b&sig=foo'
+        self.url = self.url + '/billing/request?f=b'
 
     def test_call(self):
         self.client.get(self.url)
 
         sig = parse_qs(urlparse(self.req.get.call_args[0][0]).query)['sig']
-        assert sig != 'foo', 'Signature not changed'
+        assert sig, 'A sig parameter should have been added'

--- a/lib/proxy/views.py
+++ b/lib/proxy/views.py
@@ -197,7 +197,7 @@ class ProviderProxy(Proxy):
         # The URL is made up of the defined scheme and host plus the trailing
         # URL after the proxy in urls.py.
         root = len(reverse('provider.proxy',
-                   kwargs={'reference_name':self.reference_name}))
+                   kwargs={'reference_name': self.reference_name}))
 
         self.url = url_join(self.config['url'],
                             request.META['PATH_INFO'][root:])
@@ -224,7 +224,6 @@ class BokuProxy(ProviderProxy):
         # The API request will come in with an invalid signature, lets
         # strip that out before resigning.
         qs = dict((k, v[0]) for k, v in urlparse.parse_qs(qs).items())
-        del qs['sig']
         qs['merchant-id'] = settings.BOKU_MERCHANT_ID
         # Sign the request.
         qs['sig'] = get_boku_request_signature(settings.BOKU_SECRET_KEY, qs)


### PR DESCRIPTION
This was causing a KeyError:
http://sentry.dmz.phx1.mozilla.com/marketplace-payments-alt/payments-alt-solitude-proxyallizomorg/group/19206/
