### PR TITLE
     Set buyer on transaction for Bango (bug #1034305)

### DIFF
--- a/lib/bango/tests/test_resources.py
+++ b/lib/bango/tests/test_resources.py
@@ -10,6 +10,7 @@ from django.core.urlresolvers import reverse
 import mock
 from nose.tools import eq_, ok_
 
+from lib.buyers.models import Buyer
 from lib.sellers.models import (Seller, SellerBango, SellerProduct,
                                 SellerProductBango)
 from lib.sellers.tests.utils import make_seller_paypal
@@ -45,6 +46,8 @@ class BangoAPI(APITest):
         The `without_product_bango` boolean is useful to test
         `SellerProductBango` objects creation and duplicates.
         """
+        self.buyer = Buyer.objects.create(
+            uuid=samples.good_billing_request['user_uuid'])
         self.sellers = utils.make_sellers(uuid=self.uuid)
         self.seller = self.sellers.seller
         self.seller_bango = self.sellers.bango
@@ -540,6 +543,7 @@ class TestCreateBillingConfiguration(SellerProductBangoBase):
 
         transaction = Transaction.objects.get()
         eq_(transaction.seller, self.seller)
+        eq_(transaction.buyer, self.buyer)
 
     def test_twice(self):
         data = self.good()

--- a/lib/transactions/models.py
+++ b/lib/transactions/models.py
@@ -4,6 +4,7 @@ from django.dispatch import receiver
 from django_statsd.clients import statsd
 
 from lib.bango.signals import create as bango_create
+from lib.buyers.models import Buyer
 from lib.paypal.signals import create as paypal_create
 from lib.transactions import constants
 
@@ -149,6 +150,8 @@ def create_bango_transaction(sender, **kwargs):
     bundle = kwargs['bundle'].data
     data = kwargs['data']
     form = kwargs['form']
+    buyer_uuid = form.cleaned_data['user_uuid']
+    buyer = Buyer.objects.get(uuid=buyer_uuid)
     seller = form.cleaned_data['seller_product_bango'].seller_bango.seller
     seller_product = form.cleaned_data['seller_product_bango'].seller_product
 
@@ -158,6 +161,7 @@ def create_bango_transaction(sender, **kwargs):
         provider=constants.PROVIDER_BANGO,
         seller_product=seller_product)
 
+    transaction.buyer = buyer
     transaction.seller = seller
     transaction.source = form.cleaned_data.get('source', '')
     transaction.carrier = form.cleaned_data.get('carrier', '')

--- a/lib/transactions/tests/test_api.py
+++ b/lib/transactions/tests/test_api.py
@@ -4,6 +4,7 @@ from django.core.urlresolvers import reverse
 
 from nose.tools import eq_
 
+from lib.buyers.models import Buyer
 from lib.sellers.tests.utils import make_seller_paypal
 from lib.transactions import constants
 from lib.transactions.models import Transaction
@@ -16,6 +17,7 @@ class TestTransaction(APITest):
         self.api_name = 'generic'
         self.uuid = 'sample:uid'
         self.list_url = self.get_list_url('transaction')
+        self.buyer = Buyer.objects.create(uuid='buyer_uuid')
         self.seller, self.paypal, self.product = (
             make_seller_paypal('paypal:%s' % self.uuid))
         self.trans = Transaction.objects.create(
@@ -47,6 +49,8 @@ class TestTransaction(APITest):
                 product_id=self.product.pk),
             'seller': '/generic/seller/{seller_id}/'.format(
                 seller_id=self.seller.pk),
+            'buyer': '/generic/buyer/{buyer_id}/'.format(
+                buyer_id=self.buyer.pk),
         }
 
         res = self.client.post(self.list_url, data=data)
@@ -56,6 +60,7 @@ class TestTransaction(APITest):
         json_data = json.loads(res.content)
         transaction = Transaction.objects.get(uuid=json_data['uuid'])
 
+        eq_(transaction.buyer, self.buyer)
         eq_(transaction.provider, constants.PROVIDER_BANGO)
         eq_(transaction.seller, self.seller)
         eq_(transaction.seller_product, self.product)


### PR DESCRIPTION
- Set buyer foreign key on transaction creation signal
- Update tests
