### PR TITLE
    Lazily create Buyer when starting a purchase (bug #1040321)

### DIFF
--- a/lib/bango/tests/test_resources.py
+++ b/lib/bango/tests/test_resources.py
@@ -545,6 +545,21 @@ class TestCreateBillingConfiguration(SellerProductBangoBase):
         eq_(transaction.seller, self.seller)
         eq_(transaction.buyer, self.buyer)
 
+    def test_buyer_created_when_transaction_started(self):
+        buyer_uuid = 'new-user'
+        transaction_data = self.good()
+        transaction_data['user_uuid'] = buyer_uuid
+        res = self.client.post(self.list_url, data=transaction_data)
+        eq_(res.status_code, 201, res.content)
+        assert 'billingConfigurationId' in json.loads(res.content)
+        assert 'application_size' not in json.loads(res.content)
+
+        transaction = Transaction.objects.get()
+        buyer = Buyer.objects.get(uuid=buyer_uuid)
+
+        eq_(transaction.seller, self.seller)
+        eq_(transaction.buyer, buyer)
+
     def test_twice(self):
         data = self.good()
         eq_(self.client.post(self.list_url, data=data).status_code, 201)

--- a/lib/transactions/models.py
+++ b/lib/transactions/models.py
@@ -151,7 +151,7 @@ def create_bango_transaction(sender, **kwargs):
     data = kwargs['data']
     form = kwargs['form']
     buyer_uuid = form.cleaned_data['user_uuid']
-    buyer = Buyer.objects.get(uuid=buyer_uuid)
+    buyer, created = Buyer.objects.get_or_create(uuid=buyer_uuid)
     seller = form.cleaned_data['seller_product_bango'].seller_bango.seller
     seller_product = form.cleaned_data['seller_product_bango'].seller_product
 


### PR DESCRIPTION
- Get or create buyer from UUID when starting Bango purchase
- Add test
