### PR TITLE
Bump docs reqs

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 # For buildings docs (also used by RTD)
-sphinxcontrib-httpdomain==1.1.7
-docutils==0.9.1
-Pygments==1.5
-Sphinx==1.1.3
+docutils==0.11
 mdn-sphinx-theme>=0.3
+Pygments==1.6
+Sphinx==1.2.2
+sphinxcontrib-httpdomain==1.1.9


### PR DESCRIPTION
Bump docs reqs to match webpay. This may stop some of the build errors from rtd.