### PR TITLE
add in md5 sig check (bug 1130213)

### DIFF
--- a/bin/docker/supervisor.conf
+++ b/bin/docker/supervisor.conf
@@ -12,6 +12,7 @@ stdout_logfile_maxbytes=1MB
 stopsignal=KILL
 environment=
     SOLITUDE_ZIPPY_PROXY="http://solitude:2603/proxy/provider",
+    SOLITUDE_BOKU_PROXY="http://solitude:2603/proxy/provider",
     SOLITUDE_DATABASE="mysql://root:@mysql:3306/solitude",
     MEMCACHE_URL="memcached:11211",
     SOLITUDE_URL="http://solitude:2602"

--- a/lib/boku/errors.py
+++ b/lib/boku/errors.py
@@ -1,10 +1,16 @@
 class BokuException(Exception):
 
-    def __init__(self, message, result_code=None, result_msg=None):
+    def __init__(self, message, result_code=None, result_msg=None,
+                 status=None):
         super(BokuException, self).__init__(message)
         self.result_code = result_code
         self.result_msg = result_msg
+        self.status = status
 
 
 class VerificationError(BokuException):
     """Boku failed to verify the transaction."""
+
+
+class SignatureError(BokuException):
+    """Boku failed to provide a valid signature."""

--- a/lib/provider/boku.py
+++ b/lib/provider/boku.py
@@ -33,8 +33,8 @@ class Event(viewsets.ViewSet, BaseAPIView):
         cleaned = form.cleaned_data
         transaction = cleaned['param']
 
-        # Verify this against Boku, this will raise errors if there's
-        # an issue.
+        # Verify this transaction_id against Boku, this will raise errors
+        # if the tranasction_id was not sent by Boku.
         log.info('Verifying notification for Boku transaction id: {0}'
                  .format(transaction))
 

--- a/lib/provider/tests/test_boku.py
+++ b/lib/provider/tests/test_boku.py
@@ -38,7 +38,7 @@ class TestEvent(EventTest):
     @patch('lib.boku.client.mocks', {'verify-trx-id': (500, '')})
     def test_verify_fails(self):
         self.add_seller_boku()
-        eq_(self.client.post(self.url, data=self.sample()).status_code, 200)
+        self.client.post(self.url, data=self.sample())
 
     @patch('lib.boku.client.BokuClient.api_call')
     def test_trans_failure_from_error_code(self, api):

--- a/lib/proxy/urls.py
+++ b/lib/proxy/urls.py
@@ -4,6 +4,8 @@ urlpatterns = patterns(
     '',
     url(r'^paypal$', 'lib.proxy.views.paypal', name='paypal.proxy'),
     url(r'^bango$', 'lib.proxy.views.bango', name='bango.proxy'),
+    url(r'^provider/boku/check_sig', 'lib.proxy.views.check_sig',
+        name='boku.check_sig'),
     url(r'^provider/(?P<reference_name>\w+)/', 'lib.proxy.views.provider',
-        name='provider.proxy')
+        name='provider.proxy'),
 )

--- a/solitude/settings/test.py
+++ b/solitude/settings/test.py
@@ -57,6 +57,8 @@ BANGO_MOCK = True
 ZIPPY_MOCK = True
 BOKU_MOCK = True
 
+BOKU_SECRET_KEY = 'for-testing-only'
+
 SITE_URL = 'http://localhost/'
 
 SEND_USER_ID_TO_BANGO = True


### PR DESCRIPTION
Sorry for the noise, you've seen most of this. It got simple, then complicated, then too complicated and then I removed most of that and got back to simple. Kinda embarrasing how long that took.

Here's a test in docker with an invalid signature:

```
# curl -v -X POST http://localhost:2602/provider/boku/event/ -H "Content-Type: apprx_id": '123', "action": "billingresult", "param": "foo", "sig": "not-valid"}'
...
* HTTP 1.0, assume close after body
< HTTP/1.0 400 BAD REQUEST
< Server: WSGIServer/0.1 Python/2.7.5
< Content-Length: 34
< Vary: Accept
< ETag: "14103897df789f29e185eb62f645a0dc"
< Allow: POST, OPTIONS
< Date: Tue, 03 Mar 2015 23:44:02 GMT
< Content-Type: application/json
< 
* Closing connection #0
{"sig": ["Not a valid signature"]
```

A valid signature goes on to then verify the transaction "foo" which it then fails with amusingly enough.