### PR TITLE
allow transactions to be created and errored before provider is known (bug 1140615)

### DIFF
--- a/docs/topics/generic.rst
+++ b/docs/topics/generic.rst
@@ -202,7 +202,7 @@ payment provider, a generic product must first be created.
     * ``access``: either ``1`` seller will be used for purchasing or ``2``
       seller can only be used for simulating payments.
 
-.. http:get: /generic/product/id:int/
+.. http:get:: /generic/product/id:int/
 
     Get an existing product.
 
@@ -236,17 +236,15 @@ Transaction
 A transaction is created at the start of a payment through solitude. Its
 status is altered as the transaction is completed or cancelled as appropriate.
 
-To iterate over the list of transactions::
+To iterate over the list of transactions:
 
-    GET /generic/transaction/
+.. http:get:: /generic/transaction/
 
-To get an individual transaction::
+To get an individual transaction:
 
-    GET /generic/transaction/9/
+.. http:get:: /generic/transaction/id:int/
 
-Example response:
-
-.. code-block:: json
+    .. code-block:: json
 
         {
             "amount": "0.62",
@@ -298,23 +296,66 @@ Statuses:
 * 7: ``Errored`` - the calling application (e.g. webpay) was unable to
   complete creating the transaction because of an error.
 
-To create a new transaction::
+To create a new transaction:
 
-    POST /generic/transaction/
+.. http:post:: /generic/transaction/
 
-    {
-        "amount": "0.62",
-        "buyer": null,
-        "currency": "GBP",
-        "notes": "",
-        "pay_url": "https://provider.com/pay?transaction=1234",
-        "provider": 1,
-        "seller": "/generic/seller/385/",
-        "seller_product": "/generic/product/449/",
-        "source": "bango",
-        "status": 5,
-        "type": 0,
-        "uid_pay": "230450",
-        "uid_support": "0",
-        "uuid": "webpay:d8d143f3-d484-4903-bd29-bae3d280c5b3"
-    }
+    .. code-block:: json
+
+        {
+            "amount": "0.62",
+            "buyer": null,
+            "currency": "GBP",
+            "notes": "",
+            "pay_url": "https://provider.com/pay?transaction=1234",
+            "provider": 1,
+            "seller": "/generic/seller/385/",
+            "seller_product": "/generic/product/449/",
+            "source": "bango",
+            "status": 5,
+            "type": 0,
+            "uid_pay": "230450",
+            "uid_support": "0",
+            "uuid": "webpay:d8d143f3-d484-4903-bd29-bae3d280c5b3"
+        }
+
+
+.. http:get:: /generic/transaction/id:int/
+
+    Update an existing transaction.
+
+    .. code-block:: json
+
+        {
+            "status_reason": "PROVIDER_LOOKUP_FAILURE"
+        }
+
+    **Note:** not all fields can updated all the time, the ability to update
+    a transaction is based upon logic within the transaction.
+
+    Only the following fields can be altered without limitation.
+
+    * ``notes``
+
+    * ``pay_url``
+
+    * ``status_reason``
+
+    * ``uid_pay``
+
+    Fields that can altered with limitation:
+
+    * ``provider``: can be set, only if it is not set.
+
+    * ``status``: see status notes below.
+
+    Status changes are limited in the following way:
+
+    * if a transaction was created before ``settings.TRANSACTION_LOCKDOWN``
+      then it cannot be altered.
+
+    * if a transaction is ``Failed``, ``Cancelled`` or ``Errored`` its
+      status cannot be altered.
+
+    * if a transaction is in ``Checked`` or ``Received`` it can only be moved
+      to ``Completed`` or ``Failed``.

--- a/docs/topics/generic.rst
+++ b/docs/topics/generic.rst
@@ -292,6 +292,11 @@ Statuses:
 
 * 5: ``Cancelled`` - the transaction was cancelled explicitly by the user.
 
+* 6: ``Started`` - the calling application (e.g. webpay) has started preparing
+  this transaction.
+
+* 7: ``Errored`` - the calling application (e.g. webpay) was unable to
+  complete creating the transaction because of an error.
 
 To create a new transaction::
 

--- a/lib/bango/forms.py
+++ b/lib/bango/forms.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from django import forms
 from django.conf import settings
 from django.db.models import Q
+from django.forms.models import model_to_dict
 
 import mobile_codes
 from django_statsd.clients import statsd
@@ -503,7 +504,8 @@ class EventForm(forms.Form):
             raise forms.ValidationError('Transaction not found, aborting.')
 
         data['new_status'] = {OK: STATUS_COMPLETED}[data['status']]
-        old = {'status': trans.status, 'created': trans.created}
+        old = model_to_dict(trans)
+        old['created'] = trans.created
         new = {'status': data['new_status']}
         try:
             check_status(old, new)

--- a/lib/transactions/constants.py
+++ b/lib/transactions/constants.py
@@ -26,7 +26,6 @@ STATUSES = {
 }
 STATUSES_INVERTED = dict((v, k) for k, v in STATUSES.items())
 
-
 TYPE_PAYMENT = 0
 TYPE_REFUND = 1
 TYPE_REVERSAL = 2

--- a/lib/transactions/constants.py
+++ b/lib/transactions/constants.py
@@ -7,8 +7,12 @@ STATUS_CHECKED = 2
 STATUS_RECEIVED = 3
 STATUS_FAILED = 4
 STATUS_CANCELLED = 5
+# These are statuses that reflect the transactions state in solitude
+# as it is configured by the client.
+STATUS_STARTED = 6
+STATUS_ERRORED = 7
 
-STATUS_DEFAULT = STATUS_PENDING
+STATUS_DEFAULT = STATUS_STARTED
 
 STATUSES = {
     'cancelled': STATUS_CANCELLED,
@@ -17,6 +21,8 @@ STATUSES = {
     'failed': STATUS_FAILED,
     'pending': STATUS_PENDING,
     'received': STATUS_RECEIVED,
+    'started': STATUS_STARTED,
+    'errored': STATUS_ERRORED
 }
 STATUSES_INVERTED = dict((v, k) for k, v in STATUSES.items())
 

--- a/lib/transactions/forms.py
+++ b/lib/transactions/forms.py
@@ -15,9 +15,6 @@ log = getLogger('s.transaction')
 
 
 def check_status(old, new):
-    if old['status'] == constants.STATUS_ERRORED:
-        raise forms.ValidationError('Transaction errored')
-
     if ((old['created'] + timedelta(seconds=settings.TRANSACTION_LOCKDOWN)) <
             datetime.now()):
         raise forms.ValidationError('Transaction locked down')
@@ -25,7 +22,7 @@ def check_status(old, new):
     elif old['status'] == constants.STATUS_PENDING:
         return
 
-    elif old['status'] in [constants.STATUS_FAILED, constants.STATUS_CANCELLED,
+    elif old['status'] in [constants.STATUS_FAILED, constants.STATUS_ERRORED,
                            constants.STATUS_CANCELLED]:
         msg = 'Cannot change state: {0}'.format(old['status'])
         log.error(msg)
@@ -53,8 +50,11 @@ class UpdateForm(ParanoidForm):
     notes = forms.CharField(required=False)
     status = forms.ChoiceField(choices=[(v, v) for v in STATUSES.values()],
                                required=False)
+    status_reason = forms.CharField(required=False)
     uid_pay = forms.CharField(required=False)
     pay_url = forms.URLField(required=False)
+    provider = forms.ChoiceField(choices=constants.PROVIDERS_CHOICES,
+                                 required=False)
 
     def __init__(self, *args, **kw):
         self.request = kw.pop('request')  # Storing request for CEF logs.
@@ -62,7 +62,12 @@ class UpdateForm(ParanoidForm):
         super(UpdateForm, self).__init__(*args, **kw)
 
     def clean(self):
-        keys = set(self.data.keys()).difference(set(self.fields.keys()))
+        fields = self.fields.keys()
+        # If the provider is already set, don't allow it to be changed.
+        if self.old.get('provider'):
+            del fields[fields.index('provider')]
+
+        keys = set(self.data.keys()).difference(set(fields))
         if keys:
             raise forms.ValidationError(
                 'Cannot alter fields: {0}'.format(', '.join(keys)))

--- a/lib/transactions/models.py
+++ b/lib/transactions/models.py
@@ -23,15 +23,17 @@ class Transaction(Model):
     carrier = models.CharField(max_length=255, blank=True, null=True,
                                db_index=True)
     currency = models.CharField(max_length=3, blank=True)
-    provider = models.PositiveIntegerField(choices=constants.PROVIDERS_CHOICES)
+    provider = models.PositiveIntegerField(
+        choices=constants.PROVIDERS_CHOICES, blank=True, null=True)
     # The region of the purchase.
     region = models.CharField(max_length=255, blank=True, null=True,
                               db_index=True)
     related = models.ForeignKey('self', blank=True, null=True,
                                 on_delete=models.PROTECT,
                                 related_name='relations')
-    # This is the generic seller product which is linked to a payment provider.
-    seller_product = models.ForeignKey('sellers.SellerProduct', db_index=True)
+    # This is the generic seller product which is linked to a payment provider
+    seller_product = models.ForeignKey(
+        'sellers.SellerProduct', db_index=True, blank=True, null=True)
     # This is the generic seller which is linked to the
     # "payment account setup" info. This seller may be different
     # than the one linked to via seller_product.

--- a/lib/transactions/models.py
+++ b/lib/transactions/models.py
@@ -41,6 +41,12 @@ class Transaction(Model):
                                blank=True, null=True)
     status = models.PositiveIntegerField(default=constants.STATUS_DEFAULT,
                                          choices=constants.STATUSES_CHOICES)
+    # Simple string for the reason of the status, if any further explanation
+    # is needed. These are strings, so the solitude clients can use any string
+    # they would like. Recommend keeping it short and something easy to grep
+    # in your source.
+    status_reason = models.CharField(max_length=255, blank=True, null=True)
+
     source = models.CharField(max_length=255, blank=True, null=True,
                               db_index=True)
     type = models.PositiveIntegerField(default=constants.TYPE_DEFAULT,
@@ -87,13 +93,14 @@ class Transaction(Model):
 
     def for_log(self):
         return (
-            'v4',  # Version.
+            'v5',  # Version.
             self.uuid,
             self.created.isoformat(),
             self.modified.isoformat(),
             self.amount,
             self.currency,
             self.status,
+            self.status_reason,
             self.buyer.uuid if self.buyer else None,
             self.seller_product.seller.uuid,
             self.source,

--- a/lib/transactions/resources.py
+++ b/lib/transactions/resources.py
@@ -30,8 +30,8 @@ class TransactionResource(ModelResource):
         queryset = Transaction.objects.filter()
         fields = ['uuid', 'seller_product', 'amount', 'currency',
                   'pay_url', 'provider', 'uid_pay', 'uid_support',
-                  'type', 'status', 'related', 'notes', 'created',
-                  'buyer', 'source']
+                  'type', 'status', 'status_reason', 'related', 'notes',
+                  'created', 'buyer', 'source']
         list_allowed_methods = ['get', 'post']
         allowed_methods = ['get', 'patch']
         resource_name = 'transaction'

--- a/lib/transactions/tests/test_api.py
+++ b/lib/transactions/tests/test_api.py
@@ -60,7 +60,7 @@ class TestTransaction(APITest):
                 seller_id=self.sellers.seller.pk),
             'buyer': '/generic/buyer/{buyer_id}/'.format(
                 buyer_id=self.buyer.pk),
-            'status_reason': 'ALL_COOL'
+            'status_reason': 'ALL_COOL',
         }
         res = self.client.post(self.list_url, data=data)
 
@@ -156,6 +156,7 @@ class TestTransaction(APITest):
     def test_create_minimal(self):
         res = self.client.post(self.list_url, data={})
         eq_(res.status_code, 201)
+        eq_(json.loads(res.content)['status'], constants.STATUS_STARTED)
 
     def test_patch_minimal(self):
         res = self.client.post(self.list_url, data={})

--- a/lib/transactions/tests/test_forms.py
+++ b/lib/transactions/tests/test_forms.py
@@ -60,11 +60,25 @@ class TestForm(APITest):
                           'status': constants.STATUS_STARTED},
                          {'status': constants.STATUS_COMPLETED})
 
+    def test_seller_product_needed(self):
         with self.assertRaises(ValidationError):
             check_status({'status': constants.STATUS_STARTED,
                           'provider': constants.PROVIDER_BOKU,
                           'created': datetime.now()},
                          {'status': constants.STATUS_COMPLETED})
+
+    def test_provide_set_twice(self):
+        form = UpdateForm(
+            {'status': constants.STATUS_CHECKED,
+             'provider': constants.PROVIDER_BOKU},
+            original_data={
+                'created': datetime.now(),
+                'status': constants.STATUS_COMPLETED,
+                'provider': constants.PROVIDER_BANGO,
+                'seller_product': 1,
+                },
+            request=self.req)
+        assert not form.is_valid()
 
     @patch('solitude.base._log_cef')
     def test_cef_ok(self, _log_cef):

--- a/lib/transactions/tests/test_models.py
+++ b/lib/transactions/tests/test_models.py
@@ -83,3 +83,8 @@ class TestModel(APITest):
         trans.status = constants.STATUS_COMPLETED
         trans.save()
         statsd.timing.assert_called_with('transaction.status.completed', ANY)
+
+    def test_no_provider(self):
+        data = self.get_data()
+        del data['provider']
+        Transaction.objects.create(**data)

--- a/migrations/51-make-provider-optional.sql
+++ b/migrations/51-make-provider-optional.sql
@@ -1,0 +1,2 @@
+ALTER TABLE transaction CHANGE COLUMN `seller_product_id` `seller_product_id` int(11) unsigned DEFAULT NULL;
+ALTER TABLE transaction CHANGE COLUMN `provider` `provider` int(11) unsigned DEFAULT NULL;

--- a/migrations/52-add-error-reason.sql
+++ b/migrations/52-add-error-reason.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transaction ADD COLUMN status_reason varchar(255);

--- a/migrations/52-add-error-reason.sql
+++ b/migrations/52-add-error-reason.sql
@@ -1,1 +1,1 @@
-ALTER TABLE transaction ADD COLUMN status_reason varchar(255);
+ALTER TABLE transaction ADD COLUMN status_reason varchar(255) DEFAULT NULL;


### PR DESCRIPTION
* allows a transaction to have no provider, so we can report transaction failures when there is no error
* adds in two new states
* makes ERRORED and end state, that you cannot update from