### PR TITLE
remove create signal as well (bug 1036579)

### DIFF
--- a/lib/bango/forms.py
+++ b/lib/bango/forms.py
@@ -209,9 +209,6 @@ class CreateBillingConfigurationForm(SellerProductForm):
     user_uuid = forms.CharField()
     icon_url = forms.URLField(required=False)
     application_size = forms.IntegerField(required=False)  # In bytes.
-    source = forms.CharField(required=False)
-    carrier = forms.CharField(required=False)
-    region = forms.CharField(required=False)
 
     @property
     def bango_data(self):
@@ -221,8 +218,7 @@ class CreateBillingConfigurationForm(SellerProductForm):
         application_size = data.get('application_size', 1) or 1
         application_size = long(application_size) / 1024 or 1
         data['application_size'] = int(application_size)
-        # Things that we should not pass on to Bango.
-        for k in ['prices', 'source', 'carrier', 'region']:
+        for k in ['prices']:
             del data[k]
 
         return data

--- a/lib/bango/resources/billing.py
+++ b/lib/bango/resources/billing.py
@@ -5,10 +5,7 @@ from cached import Resource
 from lib.bango.client import BangoError, get_client
 from lib.bango.constants import MICRO_PAYMENT_TYPES, PAYMENT_TYPES
 from lib.bango.forms import CreateBillingConfigurationForm
-from lib.bango.signals import create
 from lib.bango.utils import sign
-
-from lib.transactions.constants import STATUS_FAILED
 
 from solitude.constants import PAYMENT_METHOD_OPERATOR
 from solitude.logger import getLogger
@@ -54,8 +51,6 @@ class CreateBillingConfigurationResource(Resource):
         except BangoError:
             log.error('Error on createBillingConfiguration, uuid: %s'
                       % (create_data['transaction_uuid']))
-            create.send(sender=self, bundle=bundle, data=create_data,
-                        form=form, status=STATUS_FAILED)
             raise
 
         bundle.data = {'responseCode': resp.responseCode,
@@ -65,8 +60,6 @@ class CreateBillingConfigurationResource(Resource):
         log.info('Sending trans uuid %s from Bango config %s'
                  % (create_data['transaction_uuid'],
                     bundle.data['billingConfigurationId']))
-
-        create.send(sender=self, bundle=bundle, data=create_data, form=form)
         return bundle
 
     def call(self, form):

--- a/lib/bango/resources/cached.py
+++ b/lib/bango/resources/cached.py
@@ -1,9 +1,8 @@
 from django.core.urlresolvers import reverse
 
 from solitude.base import Cached, Resource as TastypieBaseResource
-from ..client import format_client_error, get_client, response_to_dict
+from ..client import format_client_error, get_client
 from ..errors import BangoFormError
-from ..signals import create
 
 
 class BangoResource(object):
@@ -73,8 +72,6 @@ class SimpleResource(Resource):
         if not form.is_valid():
             raise self.form_errors(form)
 
-        resp = self.client(self._meta.simple_api, form.bango_data,
-                           raise_on=raise_on)
-        create.send(sender=self, bundle=bundle,
-                    data=response_to_dict(resp), form=form)
+        self.client(self._meta.simple_api, form.bango_data,
+                    raise_on=raise_on)
         return bundle

--- a/lib/bango/signals.py
+++ b/lib/bango/signals.py
@@ -1,3 +1,0 @@
-import django.dispatch
-
-create = django.dispatch.Signal(providing_args=['bundle'])


### PR DESCRIPTION
Follow up to removing the implicit transaction, we no longer need the create signal and some of the data passed through to the form.