### PR TITLE
Link to braintree settings in docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,13 @@ ADD requirements /pip/requirements
 WORKDIR /pip
 # Download this securely from pyprepo first.
 RUN pip install --no-deps --find-links https://pyrepo.addons.mozilla.org/ peep
-RUN peep install -b /pip/build --download-cache /pip/cache --no-deps -r /pip/requirements/dev.txt --find-links https://pyrepo.addons.mozilla.org/
+RUN peep install \
+    --build /pip/build \
+    --download-cache /pip/cache \
+    --no-deps \
+    -r /pip/requirements/dev.txt \
+    -r /pip/requirements/docs.txt \
+    --find-links https://pyrepo.addons.mozilla.org/
 
 # Ship the source in the container, its up to docker-compose to override it
 # if it wants to.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,13 @@ exclude_patterns = ['_build']
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/topics/braintree.rst
+++ b/docs/topics/braintree.rst
@@ -3,6 +3,9 @@
 Braintree
 #########
 
+Make sure your :ref:`braintree-settings` are up to date so that
+Solitude can connect to the API.
+
 Generate a token
 ----------------
 

--- a/docs/topics/setup.rst
+++ b/docs/topics/setup.rst
@@ -83,6 +83,8 @@ You can fake out Boku for some tasks if you'd like::
 
     BOKU_MOCK = True
 
+.. _braintree-settings:
+
 Braintree settings
 ~~~~~~~~~~~~~~~~~~
 
@@ -96,7 +98,7 @@ Then go to Account > My User > API Keys. Alter your configration to read::
     BRAINTREE_PUBLIC_KEY = 'your-public-key'
     BRAINTREE_PRIVATE_KEY = 'your-private-key'
 
-What server is connected to is controlled by::
+The Braintree API server is configured by this setting::
 
     BRAINTREE_ENVIRONMENT = 'sandbox'
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,4 +3,5 @@ docutils==0.11
 mdn-sphinx-theme>=0.3
 Pygments==1.6
 Sphinx==1.2.2
+sphinx-rtd-theme==0.1.7
 sphinxcontrib-httpdomain==1.1.9


### PR DESCRIPTION
Also:
- install docs modules in docker image
- show the RTD theme when building docs locally