### PR TITLE
bump django-extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ before_install:
 install:
 - DEB_HOST_MULTIARCH=x86_64-linux-gnu pip install -I --exists-action=w "git+git://anonscm.debian.org/collab-maint/m2crypto.git@debian/0.21.1-3#egg=M2Crypto"
 - pip install --no-deps MySQL-Python==1.2.5 --use-mirrors
-- pip install --no-deps -r requirements/test.txt --find-links https://pyrepo.addons.mozilla.org/
+- pip install --find-links https://pyrepo.addons.mozilla.org/ peep
+- peep install --no-deps -r requirements/test.txt --find-links https://pyrepo.addons.mozilla.org/
 before_script:
 - mysql -e 'create database solitude;'
 - flake8 . --exclude=./docs/conf.py

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -39,9 +39,8 @@ dj-database-url==0.2.1
 # sha256: t3kyxn3ULwGhGRM94fqI7_ssTZerkDnZyVrpYEn63V8
 django-aesfield==0.1.2
 
-# sha256: W_3046UzsQJxVOY3LGuR_O08UYMjvbEjRa49NPE1068
-# sha256: z3nRsrclPDcPoMsk8koTKwegzgP-NW7qyuvYkJiyRCE
-django-extensions==0.9
+# sha256: f1GHhGqTd-WMrmWNYCSz58vQgxUnsnoB2bW1Ny0OZfY
+django-extensions==1.5.0
 
 # sha256: q3WolYCX12pkVl7RAsQndBW_mIDdJ0dzKweaayrs9D4
 django-filter==0.9.2


### PR DESCRIPTION
* the old version of django-extensions was causing a failure in schematic migrations, which was breaking solitude start up