### PR TITLE
cope with subscription cancelled

### DIFF
--- a/docs/topics/braintree.rst
+++ b/docs/topics/braintree.rst
@@ -388,12 +388,16 @@ which then passes it on to this endpoint. For more information see the
           }
         }
 
+    Note: some webhooks (such as `subscription_canceled`) may not contain a
+    transaction. If that's the case then the `mozilla.transaction` and
+    `mozilla.paymethod` fields will be empty.
+
     :>json mozilla.buyer: a :ref:`buyer <buyer-label>`.
-    :>json mozilla.paymethod: a :ref:`payment method <payment-methods-label>`.
+    :>json mozilla.paymethod: a :ref:`payment method <payment-methods-label>` (optional).
     :>json mozilla.product: a :ref:`product <seller-product>`
     :>json mozilla.subscription: a :ref:`subscription <subscription-label>`.
-    :>json mozilla.transaction.generic: a :ref:`generic transaction <transaction-label>`.
-    :>json mozilla.transaction.braintree: a :ref:`braintree transaction <braintree-transaction-label>`.
+    :>json mozilla.transaction.generic: a :ref:`generic transaction <transaction-label>` (optional).
+    :>json mozilla.transaction.braintree: a :ref:`braintree transaction <braintree-transaction-label>` (optional).
     :>json braintree.kind: the kind of webhook.
     :>json braintree.next_billing_period_amount: the amount of the next charge.
     :>json braintree.next_billing_date: the date of the next charge.

--- a/lib/brains/management/commands/samples/webhooks.py
+++ b/lib/brains/management/commands/samples/webhooks.py
@@ -98,8 +98,8 @@ sub = """<?xml version="1.0" encoding="UTF-8"?>
           <cvv-response-code>I</cvv-response-code>
           <gateway-rejection-reason nil="true"/>
           <processor-authorization-code>KQPBDL</processor-authorization-code>
-          <processor-response-code>{processor-response[code]}</processor-response-code>
-          <processor-response-text>{processor-response[text]}</processor-response-text>
+          <processor-response-code>{processor_response[code]}</processor-response-code>
+          <processor-response-text>{processor_response[text]}</processor-response-text>
           <additional-processor-response nil="true"/>
           <voice-referral-number nil="true"/>
           <purchase-order-number nil="true"/>
@@ -178,6 +178,61 @@ sub = """<?xml version="1.0" encoding="UTF-8"?>
           </risk-data>
           <three-d-secure-info nil="true"/>
         </transaction>
+      </transactions>
+      <status-history type="array">
+        <status-event>
+          <timestamp type="datetime">{timestamp}</timestamp>
+          <status>Active</status>
+          <user>andymckay</user>
+          <subscription-source>api</subscription-source>
+          <balance>0.00</balance>
+          <price>{product.amount}</price>
+        </status-event>
+      </status-history>
+    </subscription>
+  </subject>
+</notification>
+"""  # noqa
+
+no_trans = """<?xml version="1.0" encoding="UTF-8"?>
+<notification>
+  <kind>{kind}</kind>
+  <timestamp type="datetime">2015-06-15T18:34:41Z</timestamp>
+  <subject>
+    <subscription>
+      <add-ons type="array"/>
+      <balance>0.00</balance>
+      <billing-day-of-month type="integer">{now.day}</billing-day-of-month>
+      <billing-period-end-date type="date">{next:%Y-%m-%d}</billing-period-end-date>
+      <billing-period-start-date type="date">{now:%Y-%m-%d}</billing-period-start-date>
+      <created-at type="datetime">{timestamp}</created-at>
+      <updated-at type="datetime">{timestamp}</updated-at>
+      <current-billing-cycle type="integer">1</current-billing-cycle>
+      <days-past-due nil="true"/>
+      <discounts type="array"/>
+      <failure-count type="integer">0</failure-count>
+      <first-billing-date type="date">{now:%Y-%m-%d}</first-billing-date>
+      <id>{sub.provider_id}</id>
+      <merchant-account-id>{merchant_account_id}</merchant-account-id>
+      <never-expires type="boolean">true</never-expires>
+      <next-bill-amount>{product.amount}</next-bill-amount>
+      <next-billing-period-amount>{product.amount}</next-billing-period-amount>
+      <next-billing-date type="date">{next:%Y-%m-%d}</next-billing-date>
+      <number-of-billing-cycles nil="true"/>
+      <paid-through-date type="date">{paid:%Y-%m-%d}</paid-through-date>
+      <payment-method-token>7js9mb</payment-method-token>
+      <plan-id>{plan_id}</plan-id>
+      <price>{product.amount}</price>
+      <status>Active</status>
+      <trial-duration nil="true"/>
+      <trial-duration-unit>day</trial-duration-unit>
+      <trial-period type="boolean">false</trial-period>
+      <descriptor>
+        <name>Mozilla*product</name>
+        <phone nil="true"/>
+        <url>mozilla.org</url>
+      </descriptor>
+      <transactions type="array">
       </transactions>
       <status-history type="array">
         <status-event>


### PR DESCRIPTION
* update the braintree_config command to make subscription_canceled possible
* fix the spelling of subscription_canceled in the code (bah!)
* fixes #484 
* cope with the fact that there may not be transactions in the response (see #462)
* save the subscription onto the Process object to stop it being passed around