### PR TITLE
upgrade m2crypto and remove sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: python
+sudo: false
 python:
 - '2.7'
-before_install:
-- sudo apt-get update
-- sudo apt-get install swig
 install:
-- DEB_HOST_MULTIARCH=x86_64-linux-gnu pip install -I --exists-action=w "git+git://anonscm.debian.org/collab-maint/m2crypto.git@debian/0.21.1-3#egg=M2Crypto"
 - pip install --no-deps MySQL-Python==1.2.5 --use-mirrors
 - pip install --find-links https://pyrepo.addons.mozilla.org/ peep
-- peep install --no-deps -r requirements/test.txt --find-links https://pyrepo.addons.mozilla.org/
+- peep install --no-deps -r requirements/test.txt -r requirements/compiled.txt --find-links https://pyrepo.addons.mozilla.org/
 before_script:
 - mysql -e 'create database solitude;'
 after_script:

--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -1,5 +1,5 @@
-# sha256: JblEmFBcLYAO5GXbDMGv8JexYVrcOsBCochc7KJk_Ao
-M2Crypto==0.21.1
-
-# sha256: gRBAtkfl1WhvhNtBXv1pfmJQAIsRK2kJunesBZ4UDHQ
-MySQL-python==1.2.5
+# sha256: XB5NkzSqKedAx6qubwogm93yKVa1plWz2p7q3sxBCpM
+# sha256: YHG_yBfZRyPptFigENVlNlEE-EqnP3_hGRmHH3Vi_3I
+# pyrepo wheelhouse
+# sha256: eSnjUWPzFnUf4tM90UBXKeP6cJ-U_BopmJ7-gnFwXzk
+M2Crypto==0.22.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,6 @@
 # package for developers (testing, docs, etc.), it goes in this file.
 
 -r test.txt
--r compiled.txt
 
 # sha256: bpQ8fq1eguaZWQ5Uh551R1RA4bTk2gfsHkyiNCdT4bw
 autopep8==1.1.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -110,6 +110,9 @@ mock==1.0.1
 # sha256: CF23OQHqOHKKxesUGXl5rouVJFEbp_DYlB1wZQtYbvU
 mozilla-logger==0.2
 
+# sha256: gRBAtkfl1WhvhNtBXv1pfmJQAIsRK2kJunesBZ4UDHQ
+MySQL-python==1.2.5
+
 # sha256: RP1SkpqNeercGRth-qbzzkBvnJYu168x324dWc3Mrb0
 # sha256: YkKgRnEVkSBG-CQT54Olr7dLS3r_QJZI0MqmBQfUh0I
 newrelic==2.4.0.4


### PR DESCRIPTION
There are 3 (sigh) entry points into building this:

* the fabfile for prod, which calls prod.txt (so M2Crypto is built already)
* the Dockerfile which calls test.txt > dev.txt > prod.txt and docs.txt (so it skips compiled and M2Crypto is built already)
* the .travis.yml file which calls test.txt > dev.txt > prod.txt and compiled.txt (so it pulls M2Crypto from wheelhouse)