### PR TITLE
delete payment methods from braintree

### DIFF
--- a/lib/brains/tests/test_forms.py
+++ b/lib/brains/tests/test_forms.py
@@ -61,7 +61,7 @@ class TestSubscription(BraintreeTest):
 
     def test_format_descriptor(self):
         for in_string, out_string in [
-                ('Product', 'Mozilla*Product'),
-                ('Long Product With Space', 'Mozilla*Long Product W')
-            ]:
+            ('Product', 'Mozilla*Product'),
+            ('Long Product With Space', 'Mozilla*Long Product W')
+        ]:
             eq_(self.form.format_descriptor(in_string), out_string)

--- a/lib/brains/views/paymethod.py
+++ b/lib/brains/views/paymethod.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from lib.brains import serializers
 from lib.brains.client import get_client
 from lib.brains.errors import BraintreeResultError
-from lib.brains.forms import PaymentMethodForm
+from lib.brains.forms import PaymentMethodForm, PayMethodUpdateForm
 from lib.brains.models import BraintreePaymentMethod
 from solitude.base import NoAddModelViewSet
 from solitude.constants import PAYMENT_METHOD_CARD
@@ -55,3 +55,14 @@ class PaymentMethodViewSet(NoAddModelViewSet):
     serializer_class = serializers.LocalPayMethod
     filter_fields = ('braintree_buyer', 'braintree_buyer__buyer__uuid',
                      'active')
+
+    def update(self, request, *args, **kwargs):
+        form = PayMethodUpdateForm(request.DATA, self.get_object_or_none())
+
+        if not form.is_valid():
+            raise FormError(form.errors)
+
+        return (
+            super(PaymentMethodViewSet, self)
+            .update(request, *args, **kwargs)
+        )


### PR DESCRIPTION
* calls delete upon changing status to active
* if this happens multiple times it doesn't fail
* fixes #492 and supports mozilla/payments#84
* also prevents enabling a deactivated payment method which fixes #494 