### PR TITLE
Cancel subscription

### DIFF
--- a/docs/topics/braintree.rst
+++ b/docs/topics/braintree.rst
@@ -232,11 +232,19 @@ Change payment method on a subscription:
 .. http:post:: /braintree/subscription/paymethod/change/
 
     :<json string paymethod: the resource_uri of the paymethod in solitude.
+
+    :status 200: subscription changed.
+
+Cancel a subscription. This will cancel the subscription in Braintree and is
+not reversible.
+
+.. http:post:: /braintree/subscription/cancel/
+
     :<json string subscription: the resource_uri of the subscription in solitude.
 
     The response is in the same format as for creation.
 
-    :status 200: subscription changed.
+    :status 200: subscription cancelled.
 
 Data stored in solitude
 +++++++++++++++++++++++

--- a/lib/brains/forms.py
+++ b/lib/brains/forms.py
@@ -210,3 +210,18 @@ class SubscriptionUpdateForm(forms.Form):
                 'Cannot use an inactive payment method', code='invalid')
 
         return self.cleaned_data
+
+
+class SubscriptionCancelForm(forms.Form):
+    subscription = PathRelatedFormField(
+        view_name='braintree:mozilla:subscription-detail',
+        queryset=BraintreeSubscription.objects.filter())
+
+    def clean(self):
+        solitude_subscription = self.cleaned_data.get('subscription')
+
+        if not solitude_subscription.active:
+            raise forms.ValidationError(
+                'Cannot cancel an inactive subscription', code='invalid')
+
+        return self.cleaned_data

--- a/lib/brains/urls.py
+++ b/lib/brains/urls.py
@@ -21,6 +21,8 @@ urlpatterns = patterns(
     url(r'^paymethod/$', 'paymethod.create', name='paymethod'),
     url(r'^paymethod/delete/$', 'paymethod.delete', name='paymethod.delete'),
     url(r'^subscription/$', 'subscription.create', name='subscription'),
+    url(r'^subscription/cancel/$', 'subscription.cancel',
+        name='subscription.cancel'),
     url(r'^subscription/paymethod/change/$', 'subscription.change',
         name='subscription.change'),
     url(r'^webhook/$', 'webhook.webhook', name='webhook'),


### PR DESCRIPTION
* won't allow a subscription to be reactivated
* cancels the subscription in braintree

```
curl --dump-header - -H "Content-Type: application/json" -X POST --data '{"subscription": "/braintree/mozilla/subscription/1/"} http://solitude:2602/braintree/subscription/cancel/
```