### PR TITLE
improved pay method

### DIFF
--- a/docs/topics/braintree.rst
+++ b/docs/topics/braintree.rst
@@ -99,12 +99,12 @@ Some information is stored in solitude after creating a customer.
 Payment Methods
 ---------------
 
-Creates a payment method in Braintree and the corresponding payment method in
-solitude.
+Create or update a payment method in Braintree and the corresponding payment
+method in solitude.
 
 .. http:post:: /braintree/paymethod/
 
-    :<json string uuid: the uuid of the buyer in solitude.
+    :<json string buyer_uuid: the uuid of the buyer in solitude.
     :<json string nonce: the payment nonce returned by Braintree.
 
     .. code-block:: json
@@ -131,11 +131,22 @@ solitude.
             }
         }
 
-    :>json string braintree token: id of the payment method in braintree.
+    :>json string braintree token: id of the payment method in Braintree.
     :>json string braintree created_at: created date and time.
     :>json string braintree updated_at: updated date and time.
 
     :status 201: payment method created.
+
+Delete a payment method. This will delete the payment method in Braintree
+and is not reversible.
+
+.. http:post:: /braintree/paymethod/delete/
+
+    :<json string paymethod: the resource_uri of the payment method in solitude.
+
+    The response is in the same format as for creation.
+
+    :status 200: payment method cancelled.
 
 Data stored in solitude
 +++++++++++++++++++++++
@@ -168,10 +179,6 @@ Some information about the payment method is stored in solitude.
                                 for a credit card, the last 4 digits, this field is read only.
     :>json int type: `1` for credit card is currently the only one supported, this field is read only.
     :>json string type_name: name of the type of purchase, this field is read only.
-
-.. http:patch:: /braintree/mozilla/paymethod/<method id>/
-
-    :<json boolean active: if the payment method is currently active.
 
 .. http:get:: /braintree/mozilla/paymethod/
 

--- a/lib/brains/forms.py
+++ b/lib/brains/forms.py
@@ -3,10 +3,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
 import requests
-from braintree.exceptions.not_found_error import NotFoundError
 
-from lib.brains.client import get_client
-from lib.brains.errors import BraintreeResultError
 from lib.brains.models import BraintreeBuyer, BraintreePaymentMethod
 from lib.buyers.models import Buyer
 from lib.sellers.models import SellerProduct
@@ -172,43 +169,20 @@ class WebhookParseForm(forms.Form):
         return self.cleaned_data
 
 
-class PayMethodUpdateForm(forms.Form):
-    active = forms.BooleanField(required=False)
+class PayMethodDeleteForm(forms.Form):
+    paymethod = PathRelatedFormField(
+        view_name='braintree:mozilla:paymethod-detail',
+        queryset=BraintreePaymentMethod.objects.filter())
 
-    def __init__(self, data, obj):
-        self.object = obj
-        return super(PayMethodUpdateForm, self).__init__(data)
-
-    def clean_active(self):
-        active = self.cleaned_data['active']
-
-        # An attempt to enable active on the payment method.
-        if active and not self.object.active:
+    def clean(self):
+        solitude_method = self.cleaned_data.get('paymethod')
+        if not solitude_method:
             raise forms.ValidationError(
-                'Cannot set an inactive payment method to active',
-                code='invalid')
+                'Paymethod is required', code='required')
 
-        # Disabling a payment method.
-        #
-        # Deletes the payment method from Braintree. See:
-        # http://bit.ly/1g82b0Q for more.
-        if not active and self.object.active:
-            log.info('Payment method set inactive in solitude: {}'
-                     .format(self.object.pk))
-            client = get_client().PaymentMethod
-            try:
-                result = client.delete(self.object.provider_id)
-                if not result.is_success:
-                    log.warning('Error on deleting Payment method: {} {}'
-                                .format(self.object.pk, result.message))
-                    raise BraintreeResultError(result)
-            except NotFoundError:
-                # Repeated deletes hit a NotFoundError, if we assume that
-                # deletes should be idempotent, we can catch and ignore this.
-                log.info('Payment method not found: {}'.format(self.object.pk))
-                return
+        # An attempt to delete an inactive payment.
+        if not solitude_method.active:
+            raise forms.ValidationError(
+                'Cannot delete an inactive payment method', code='invalid')
 
-            log.info('Payment method deleted from braintree: {}'
-                     .format(self.object.pk))
-
-        return active
+        return self.cleaned_data

--- a/lib/brains/urls.py
+++ b/lib/brains/urls.py
@@ -19,6 +19,7 @@ urlpatterns = patterns(
     url(r'^token/generate/$', 'token.generate', name='token.generate'),
     url(r'^customer/$', 'customer.create', name='customer'),
     url(r'^paymethod/$', 'paymethod.create', name='paymethod'),
+    url(r'^paymethod/delete/$', 'paymethod.delete', name='paymethod.delete'),
     url(r'^subscription/$', 'subscription.create', name='subscription'),
     url(r'^webhook/$', 'webhook.webhook', name='webhook'),
 )


### PR DESCRIPTION
* proposed change to paymethod cancelling, just an explicit end point
* seperates braintree and mozillay
Now to cancel:

```
curl --dump-header - -H "Content-Type: application/json" -X POST --data '{"paymethod": "/braintree/mozilla/paymethod/1/"} http://solitude:2602/braintree/paymethod/cancel/
```

* this would mean removing the ability to patch /braintree/paymethod/1/ from the bodyguard and changing to this.