### PR TITLE
change a subscriptions paymethod

### DIFF
--- a/docs/topics/braintree.rst
+++ b/docs/topics/braintree.rst
@@ -227,6 +227,16 @@ solitude.
 
     :status 201: payment method created.
 
+Change payment method on a subscription:
+
+.. http:post:: /braintree/subscription/paymethod/change/
+
+    :<json string paymethod: the resource_uri of the paymethod in solitude.
+    :<json string subscription: the resource_uri of the subscription in solitude.
+
+    The response is in the same format as for creation.
+
+    :status 200: subscription changed.
 
 Data stored in solitude
 +++++++++++++++++++++++

--- a/lib/brains/forms.py
+++ b/lib/brains/forms.py
@@ -4,7 +4,8 @@ from django.core.exceptions import ObjectDoesNotExist
 
 import requests
 
-from lib.brains.models import BraintreeBuyer, BraintreePaymentMethod
+from lib.brains.models import (
+    BraintreeBuyer, BraintreePaymentMethod, BraintreeSubscription)
 from lib.buyers.models import Buyer
 from lib.sellers.models import SellerProduct
 from payments_config import products
@@ -184,5 +185,28 @@ class PayMethodDeleteForm(forms.Form):
         if not solitude_method.active:
             raise forms.ValidationError(
                 'Cannot delete an inactive payment method', code='invalid')
+
+        return self.cleaned_data
+
+
+class SubscriptionUpdateForm(forms.Form):
+    paymethod = PathRelatedFormField(
+        view_name='braintree:mozilla:paymethod-detail',
+        queryset=BraintreePaymentMethod.objects.filter())
+    subscription = PathRelatedFormField(
+        view_name='braintree:mozilla:subscription-detail',
+        queryset=BraintreeSubscription.objects.filter())
+
+    def clean(self):
+        solitude_subscription = self.cleaned_data.get('subscription')
+        solitude_method = self.cleaned_data.get('paymethod')
+
+        if not solitude_subscription.active:
+            raise forms.ValidationError(
+                'Cannot alter an inactive subscription', code='invalid')
+
+        if not solitude_method.active:
+            raise forms.ValidationError(
+                'Cannot use an inactive payment method', code='invalid')
 
         return self.cleaned_data

--- a/lib/brains/urls.py
+++ b/lib/brains/urls.py
@@ -21,5 +21,7 @@ urlpatterns = patterns(
     url(r'^paymethod/$', 'paymethod.create', name='paymethod'),
     url(r'^paymethod/delete/$', 'paymethod.delete', name='paymethod.delete'),
     url(r'^subscription/$', 'subscription.create', name='subscription'),
+    url(r'^subscription/paymethod/change/$', 'subscription.change',
+        name='subscription.change'),
     url(r'^webhook/$', 'webhook.webhook', name='webhook'),
 )

--- a/lib/brains/views/subscription.py
+++ b/lib/brains/views/subscription.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 
 from lib.brains.client import get_client
 from lib.brains.errors import BraintreeResultError
-from lib.brains.forms import SubscriptionForm
+from lib.brains.forms import SubscriptionForm, SubscriptionUpdateForm
 from lib.brains.models import BraintreeSubscription
 from lib.brains.serializers import (
     LocalSubscription, Namespaced, Subscription)
@@ -12,6 +12,39 @@ from solitude.errors import FormError
 from solitude.logger import getLogger
 
 log = getLogger('s.brains')
+
+
+@api_view(['POST'])
+def change(request):
+    client = get_client().Subscription
+    form = SubscriptionUpdateForm(request.DATA)
+
+    if not form.is_valid():
+        raise FormError(form.errors)
+
+    subscription = form.cleaned_data['subscription']
+    method = form.cleaned_data['paymethod']
+    result = client.update(
+        subscription.provider_id,
+        {'payment_method_token': method.provider_id}
+    )
+
+    log_msgs = (subscription.id, subscription.paymethod_id, method.pk)
+
+    if not result.is_success:
+        log.warning('Error on changing subscription: {} from {} to {}'
+                    .format(*log_msgs))
+        raise BraintreeResultError(result)
+
+    subscription.paymethod = method
+    subscription.save()
+
+    log.info('Subscription changed: {} from {} to {}'.format(*log_msgs))
+    res = Namespaced(
+        mozilla=LocalSubscription(instance=subscription),
+        braintree=Subscription(instance=result.subscription)
+    )
+    return Response(res.data, status=200)
 
 
 @api_view(['POST'])


### PR DESCRIPTION
* won't allow you to use an inactive subscription or paymethod

```
curl --dump-header - -H "Content-Type: application/json" -X POST --data '{"subscription": "/braintree/mozilla/subscription/2/", "paymethod": "/braintree/mozilla/paymethod/1/"}' http://solitude:2602/braintree/subscription/change/
```
