### PR TITLE
pass the right URL

### DIFF
--- a/lib/provider/client.py
+++ b/lib/provider/client.py
@@ -34,7 +34,7 @@ class APIMockObject(object):
     def __call__(self, pk):
         return self.__class__(self.resource_name, pk)
 
-    def get(self):
+    def get(self, **kwargs):
         if self.pk:
             return self.get_data(self.resource_name)[self.pk]
         else:
@@ -45,7 +45,7 @@ class APIMockObject(object):
         """Exists to make mock patching easy."""
         return mock_data[resource_name]
 
-    def post(self, data):
+    def post(self, data, **kwargs):
         id = data.get('pk', data.get('external_id'))
         data['uuid'] = 'ref:uuid'
         data['resource_pk'] = self.pk
@@ -56,13 +56,13 @@ class APIMockObject(object):
         mock_data[self.resource_name][id] = data
         return self.get_data(self.resource_name)[id]
 
-    def put(self, data):
+    def put(self, data, **kwargs):
         initial_data = self.get_data(self.resource_name)[self.pk]
         initial_data.update(data)
         mock_data[self.resource_name][self.pk] = initial_data
         return mock_data[self.resource_name][self.pk]
 
-    def delete(self):
+    def delete(self, **kwargs):
         del mock_data[self.resource_name][self.pk]
 
 

--- a/lib/provider/tests/test_reference.py
+++ b/lib/provider/tests/test_reference.py
@@ -88,7 +88,7 @@ class TestSellerProductReferenceView(SellerTest):
             'external_id': self.product.external_id,
             'uuid': 'some:uuid',
             'name': 'bob'
-        })
+        }, headers={'x-solitude-service': 'http://zippy:2605'})
 
     def test_get(self):
         ref = self.create_provider_product()

--- a/lib/provider/tests/test_views.py
+++ b/lib/provider/tests/test_views.py
@@ -43,9 +43,6 @@ class TestAPIasProxy(TestCase):
         self.addCleanup(p.stop)
 
         self.api = mock.MagicMock()
-        store = mock.Mock()
-        store._store = {'base_url': 'http://f'}
-        self.api.products.get.__self__ = store
         get_client.return_value = mock.Mock(api=self.api)
 
         self.fake_data = {'foo': 'bar'}
@@ -65,7 +62,7 @@ class TestAPIasProxy(TestCase):
         self.request('get', '/reference/products?foo=bar', 'products')
         assert self.api.products.get.called
         result = self.fake_data.copy()
-        result.update({'headers': {'x-solitude-service': 'http://f'}})
+        result.update({'headers': {'x-solitude-service': 'http://zippy:2605'}})
         eq_(self.api.products.get.call_args[1], result)
 
     def test_proxy_error_responses(self):

--- a/lib/provider/views.py
+++ b/lib/provider/views.py
@@ -74,14 +74,9 @@ class ProxyView(BaseAPIView):
     def result(self, proxied_endpoint, *args, **kwargs):
         method = getattr(proxied_endpoint, '__name__', 'unknown_method')
 
-        # Not all test mocks have this. Someone more dedicated than me
-        # can fix up all the tests for this soon to be deleted feature.
-        if (hasattr(proxied_endpoint, '__self__')
-                and hasattr(proxied_endpoint.__self__, '_store')):
-            # Pass the real URL through in the HTTP header to the proxy.
-            kwargs.setdefault('headers', {})
-            kwargs['headers'][settings.AUTH_SERVICE] = (
-                proxied_endpoint.__self__._store['base_url'])
+        kwargs.setdefault('headers', {})
+        kwargs['headers'][settings.AUTH_SERVICE] = (
+            settings.ZIPPY_CONFIGURATION[self.reference_name]['url'])
 
         try:
             with statsd.timer('solitude.provider.{ref}.proxy.{method}'

--- a/solitude/settings/base.py
+++ b/solitude/settings/base.py
@@ -460,7 +460,7 @@ BANGO_NOTIFICATION_URL = ''
 # Mock out Zippy, because we are sharing zippy.paas configuration.
 ZIPPY_MOCK = False
 
-url = os.environ.get('ZIPPY_BASE_URL', 'https://zippy.paas.allizom.org')
+url = os.environ.get('ZIPPY_BASE_URL', 'http://zippy:2605')
 
 # Override this to configure some zippy backends.
 ZIPPY_CONFIGURATION = {


### PR DESCRIPTION
* i was passing through to the auth that the final destination of zippy... was solitude-auth, that's silly the final URL for zippy requests is zippy, that's what the header is for
* let's move the final url calculation into the proxy, that's what the current lib/proxy does and makes this code easier
* let's set the default url to be the docker one, not paas