### PR TITLE
no need for solitude proxy any more

### DIFF
--- a/bin/docker/supervisor.conf
+++ b/bin/docker/supervisor.conf
@@ -11,33 +11,7 @@ stdout_logfile=logs/docker.log
 stdout_logfile_maxbytes=1MB
 stopsignal=KILL
 environment=
-    # See also the payments-env docker files for environment vars.
-
-    # Note: that this proxy setting will be replaced when solitude-auth
-    # is completed for all providers.
-    SOLITUDE_ZIPPY_PROXY="http://solitude-auth:2603/v1/reference/",
     SOLITUDE_URL="http://solitude:2602"
-
-# Note: that this will be removed when solitude-auth is completed for all
-# providers.
-[program:proxy]
-# There's no need to wrap this command because it doesn't need mysql
-# or other things.
-command=python /srv/solitude/manage.py runserver 0.0.0.0:2603
-directory=/srv/solitude
-stopasgroup=true
-autostart=true
-redirect_stderr=true
-stdout_logfile=logs/docker-proxy.log
-stdout_logfile_maxbytes=1MB
-stopsignal=KILL
-# This will turn on the proxy.
-environment=
-    SOLITUDE_DATABASE="",
-    SOLITUDE_PROXY="enabled"
-
-
-# The following sections enable supervisorctl.
 
 [inet_http_server]
 port=9001

--- a/lib/provider/tests/test_views.py
+++ b/lib/provider/tests/test_views.py
@@ -28,9 +28,11 @@ class TestAPIView(TestCase):
 
     def test_no_reference(self):
         req = RequestFactory().get('/')
-        with self.settings(ZIPPY_MOCK=False):
-            eq_(ProxyView().dispatch(req, reference_name='bob',
-                                     resource_name='sellers').status_code, 404)
+        with self.assertRaises(KeyError):
+            with self.settings(ZIPPY_MOCK=False):
+                eq_(ProxyView().dispatch(
+                    req, reference_name='bob',
+                    resource_name='sellers').status_code, 404)
 
 
 class TestAPIasProxy(TestCase):

--- a/solitude/settings/base.py
+++ b/solitude/settings/base.py
@@ -477,7 +477,8 @@ ZIPPY_CONFIGURATION = {
 }
 
 # The URL for a solitude proxy to zippy.
-ZIPPY_PROXY = os.getenv('SOLITUDE_ZIPPY_PROXY', '')
+ZIPPY_PROXY = os.getenv(
+    'SOLITUDE_ZIPPY_PROXY', 'http://solitude-auth:2603/v1/reference/')
 
 # End Zippy settings.
 ###############################################################################


### PR DESCRIPTION
* things go through solitude-auth now, so remove the second process inside the solitude container
* set the default in settings to solitude-auth for docker to save another env variable
* fixes #515 