### PR TITLE
Fix return result of pay method deletion

### DIFF
--- a/docs/topics/braintree.rst
+++ b/docs/topics/braintree.rst
@@ -144,9 +144,7 @@ and is not reversible.
 
     :<json string paymethod: the resource_uri of the payment method in solitude.
 
-    The response is in the same format as for creation.
-
-    :status 200: payment method cancelled.
+    :status 204: payment method deleted.
 
 Data stored in solitude
 +++++++++++++++++++++++

--- a/lib/brains/tests/test_paymethod.py
+++ b/lib/brains/tests/test_paymethod.py
@@ -102,11 +102,11 @@ class TestPaymentMethod(BraintreeTest):
         eq_(self.braintree_error(res.json, 'payment_method_nonce'), ['91925'])
 
 
-class TestPaymentMethodCancel(BraintreeTest):
+class TestDeletePaymentMethod(BraintreeTest):
     gateways = {'method': PaymentMethodGateway}
 
     def setUp(self):
-        super(TestPaymentMethodCancel, self).setUp()
+        super(TestDeletePaymentMethod, self).setUp()
         self.url = reverse('braintree:paymethod.delete')
 
     def test_allowed(self):
@@ -126,11 +126,11 @@ class TestPaymentMethodCancel(BraintreeTest):
 
         obj = self.create_paymethod()
         res = self.post(obj)
-        eq_(res.status_code, 200, res.status_code)
+        eq_(res.status_code, 204, res.status_code)
 
         self.mocks['method'].delete.assert_called_with(obj.provider_id)
 
-    def test_fails_post(self):
+    def test_braintree_delete_failure(self):
         self.mocks['method'].delete.return_value = error()
 
         obj = self.create_paymethod()
@@ -140,7 +140,7 @@ class TestPaymentMethodCancel(BraintreeTest):
 
         self.mocks['method'].delete.assert_called_with(obj.provider_id)
 
-    def test_active_post(self):
+    def test_cannot_delete_inactive_paymethod(self):
         obj = self.create_paymethod()
         obj.active = False
         obj.save()

--- a/lib/brains/views/paymethod.py
+++ b/lib/brains/views/paymethod.py
@@ -22,18 +22,14 @@ def delete(request):
         raise FormError(form.errors)
 
     solitude_method = form.cleaned_data['paymethod']
-    result = solitude_method.braintree_delete()
+    solitude_method.braintree_delete()
     solitude_method.active = False
     solitude_method.save()
 
     log.info('Payment method deleted from braintree: {}'
              .format(solitude_method.pk))
 
-    res = serializers.Namespaced(
-        mozilla=serializers.LocalPayMethod(instance=solitude_method),
-        braintree=serializers.PayMethod(instance=result.payment_method)
-    )
-    return Response(res.data)
+    return Response({}, status=204)
 
 
 @api_view(['POST'])


### PR DESCRIPTION
The braintree result does not contain the payment_method definition.