### PR TITLE
Set SITE URL as a variable for the payments-proxy

### DIFF
--- a/solitude/settings/sites/prod/proxy.py
+++ b/solitude/settings/sites/prod/proxy.py
@@ -42,7 +42,7 @@ CLIENT_JWT_KEYS = private.CLIENT_JWT_KEYS
 NOSE_PLUGINS = []
 
 REQUIRE_OAUTH = False
-SITE_URL = 'https://payments-proxy.firefox.com'
+SITE_URL = private.SITE_URL
 
 # Below is configuration of payment providers.
 ZIPPY_CONFIGURATION = {}


### PR DESCRIPTION
From Bug 1191932:

Greetings,

We'd like to set the SITE_URL as a variable for payments-proxy.  I've created a PR here, which seems like a small change, but wanted to verify with the dev team that this would not impact anything else.

The current SITE_URL for prod is set to https://payments-proxy.firefox.com, where we would want to configure that to https://payments-proxy.prod.mozaws.net as a variable instead of a static entry.

Thanks!