### PR TITLE
turn on atomic requests on prod

### DIFF
--- a/solitude/exceptions.py
+++ b/solitude/exceptions.py
@@ -13,6 +13,7 @@ log = getLogger('s')
 def custom_exception_handler(exc):
     # If you raise an error in solitude, it comes to here and
     # we rollback the transaction.
+    log.exception('Handling exception, about to roll back', exc_info=exc)
     set_rollback(True)
 
     if hasattr(exc, 'formatter'):

--- a/solitude/settings/sites/dev/db.py
+++ b/solitude/settings/sites/dev/db.py
@@ -21,6 +21,7 @@ DATABASES = {}
 DATABASES['default'] = dj_database_url.parse(private.DATABASES_DEFAULT_URL)
 DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
 DATABASES['default']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 DEBUG = False
 DEBUG_PROPAGATE_EXCEPTIONS = False

--- a/solitude/settings/sites/paymentsalt/db.py
+++ b/solitude/settings/sites/paymentsalt/db.py
@@ -17,6 +17,7 @@ DATABASES = {}
 DATABASES['default'] = dj_database_url.parse(private.DATABASES_DEFAULT_URL)
 DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
 DATABASES['default']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 DEBUG = False
 DEBUG_PROPAGATE_EXCEPTIONS = False

--- a/solitude/settings/sites/prod/db.py
+++ b/solitude/settings/sites/prod/db.py
@@ -16,6 +16,7 @@ DATABASES = {}
 DATABASES['default'] = dj_database_url.parse(private.DATABASES_DEFAULT_URL)
 DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
 DATABASES['default']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 DEBUG = False
 DEBUG_PROPAGATE_EXCEPTIONS = False

--- a/solitude/settings/sites/stage/db.py
+++ b/solitude/settings/sites/stage/db.py
@@ -17,6 +17,7 @@ DATABASES = {}
 DATABASES['default'] = dj_database_url.parse(private.DATABASES_DEFAULT_URL)
 DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
 DATABASES['default']['OPTIONS'] = {'init_command': 'SET storage_engine=InnoDB'}
+DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 DEBUG = False
 DEBUG_PROPAGATE_EXCEPTIONS = False


### PR DESCRIPTION
* fixes #520 
* log before we attempt the roll back
* `DATABASES['default']` is being overridden, meaning we weren't in an atomic block although the code assumed that