### PR TITLE
fix the ordering

### DIFF
--- a/lib/transactions/models.py
+++ b/lib/transactions/models.py
@@ -72,7 +72,6 @@ class Transaction(Model):
 
     class Meta(Model.Meta):
         db_table = 'transaction'
-        ordering = ('-id',)
         unique_together = (('uid_pay', 'provider'),
                            ('uid_support', 'provider'))
 

--- a/lib/transactions/tests/test_api.py
+++ b/lib/transactions/tests/test_api.py
@@ -169,3 +169,8 @@ class TestTransaction(APITest):
         res = self.client.patch(res.json['resource_uri'],
                                 data={'status': constants.STATUS_ERRORED})
         eq_(res.json['uuid'], 'test:uuid')
+
+    def test_newest_first(self):
+        Transaction.objects.create(uuid='newest')
+        res = self.client.get(self.list_url)
+        eq_([o['uuid'] for o in res.json['objects']], ['newest', self.uuid])

--- a/solitude/base.py
+++ b/solitude/base.py
@@ -281,8 +281,8 @@ class Model(models.Model):
 
     class Meta:
         abstract = True
-        ordering = ('-created',)
-        get_latest_by = 'created'
+        ordering = ('-id',)
+        get_latest_by = 'id'
 
     def reget(self):
         return self.__class__.objects.get(pk=self.pk)

--- a/solitude/filter.py
+++ b/solitude/filter.py
@@ -1,6 +1,9 @@
 from rest_framework.filters import DjangoFilterBackend
 
 from solitude.errors import InvalidQueryParams
+from solitude.logger import getLogger
+
+log = getLogger('s.filter')
 
 
 class StrictQueryFilter(DjangoFilterBackend):
@@ -9,6 +12,16 @@ class StrictQueryFilter(DjangoFilterBackend):
     Don't allow people to typo request params and return all the objects.
     Instead limit it down to the parameters allowed in filter_fields.
     """
+
+    def get_filter_class(self, view, queryset=None):
+        klass = (super(StrictQueryFilter, self)
+                 .get_filter_class(view, queryset=queryset))
+        try:
+            # If an ordering exists on the model, use that.
+            klass._meta.order_by = klass.Meta.model.Meta.ordering
+        except AttributeError:
+            pass
+        return klass
 
     def filter_queryset(self, request, queryset, view):
         requested = set(request.QUERY_PARAMS.keys())

--- a/solitude/tests/test.py
+++ b/solitude/tests/test.py
@@ -96,6 +96,11 @@ class TestStrictQueryFilter(APITest):
         self.req.QUERY_PARAMS = {'uid': ['bar']}  # Note the typo there.
         StrictQueryFilter().filter_queryset(self.req, self.queryset, self.view)
 
+    def test_order(self):
+        klass = StrictQueryFilter().get_filter_class(
+            self.view, queryset=self.queryset)
+        eq_(klass._meta.order_by, ('-id',))
+
 
 class TestShorter(TestCase):
 


### PR DESCRIPTION
* fixes #523 
* pass on the ordering on the model down to django-filter, kinda confused why DRF doesn't do this already
* can't think of anything that explicitly relies on ordering in solitude, so should be ok

fyi @muffinresearch, this will ensure payment methods are ordered newest first