### PR TITLE
close account api

### DIFF
--- a/docs/topics/generic.rst
+++ b/docs/topics/generic.rst
@@ -213,7 +213,7 @@ After these two steps you will use the ``reset_confirm_pin`` endpoint. It works
 the same way as the ``confirm_pin`` endpoint but instead checks against the
 buyer's ``new_pin`` rather than their ``pin``:
 
-.. htp:post::: /generic/reset_confirm_pin/
+.. http:post::: /generic/reset_confirm_pin/
 
     **Request**
 
@@ -246,6 +246,42 @@ minutes. You can tell if a buyer is locked by checking the
 ``pin_is_locked_out`` property of the buyer data. Buyers that were locked out
 since the last time the PIN was changed or successfully verified will have the
 ``pin_was_locked_out`` property set to ``true``.
+
+Close
+-----
+
+This does not delete the buyer, but does the following:
+
+* calls a close signal the payment providers can listen to, in the case of Braintree it cancels all payment methods and subscriptions
+* sets the account to inactive
+* removes the email
+* sets the uuid to something anonymous
+
+Note: only if the close signal is succesfully processed will the account be set to inactive.
+
+.. http:post:: /generic/buyer/int:id/close/
+
+    :status 204: account closed successfully
+    :status 400: problem processing the uuid into a buyer
+    :status 404: active buyer not found, will trigger if you try to close an account twice
+    :status 500: something went wrong with closing the account
+
+The account is not deleted and can still be accessed by the URL to that account to preserve data integrity. For example:
+
+* create a buyer with a POST to `/generic/buyer`
+* store the `resource_uri` in the response
+* close the buyer with a POST to `/generic/buyer/int:id/close`
+* get the buyer with a GET to `resource_uri`, a *truncated* version of the response shows:
+
+  .. code-block:: json
+
+    {
+        "active": False,
+        "email": "",
+        "uuid": "anonymised-uuid:1b3db7a9-0e8f-43d8-b8da-b3317a147068"
+    }
+
+
 
 .. _seller-label:
 

--- a/lib/buyers/tests/test_api.py
+++ b/lib/buyers/tests/test_api.py
@@ -374,3 +374,22 @@ class TestBuyerResetPin(APITest):
     def test_empty_post(self):
         res = self.client.post(self.list_url, data={})
         eq_(res.status_code, 422)
+
+
+class TestBuyerClose(APITest):
+
+    def setUp(self):
+        self.uuid = 'sample:uid'
+        self.buyer = Buyer.objects.create(uuid=self.uuid)
+        self.url = reverse('generic:close', kwargs={'pk': self.buyer.pk})
+
+    def test_close(self):
+        res = self.client.post(self.url)
+        eq_(res.status_code, 204)
+        eq_(self.buyer.reget().active, False, res.content)
+
+    def test_already_closed(self):
+        self.buyer.active = False
+        self.buyer.save()
+        res = self.client.post(self.url)
+        eq_(res.status_code, 404, res.content)

--- a/lib/buyers/urls.py
+++ b/lib/buyers/urls.py
@@ -10,8 +10,9 @@ router.register(r'buyer', views.BuyerViewSet)
 urlpatterns = patterns(
     '',
     url(r'', include(router.urls)),
-    url(r'^confirm_pin', views.confirm_pin, name='confirm'),
-    url(r'^verify_pin', views.verify_pin, name='verify'),
-    url(r'^reset_confirm_pin', views.reset_confirm_pin,
+    url(r'^generic/buyer/(?P<pk>[\d]+)/close/$', views.close, name='close'),
+    url(r'^confirm_pin$', views.confirm_pin, name='confirm'),
+    url(r'^verify_pin$', views.verify_pin, name='verify'),
+    url(r'^reset_confirm_pin$', views.reset_confirm_pin,
         name='reset_confirm_pin')
 )

--- a/lib/buyers/views.py
+++ b/lib/buyers/views.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
@@ -7,6 +9,9 @@ from lib.buyers.serializers import (
     BuyerSerializer, ConfirmedSerializer, VerifiedSerializer)
 from solitude.base import log_cef, NonDeleteModelViewSet
 from solitude.errors import FormError
+from solitude.logger import getLogger
+
+log = getLogger('s.buyer')
 
 
 class BuyerViewSet(NonDeleteModelViewSet):
@@ -98,3 +103,11 @@ def reset_confirm_pin(request):
         return Response(output.data)
 
     raise FormError(form.errors)
+
+
+@api_view(['POST'])
+def close(request, pk):
+    buyer = get_object_or_404(Buyer, pk=pk, active=True)
+    log.info('Closing account for: {}'.format(buyer.pk))
+    buyer.close()
+    return Response(status=204)


### PR DESCRIPTION
* hook up model method into the API
* `/generic/buyer/id/close/` is a nice URL, but kinda awkward to put together in payments-service, maybe? if you want a different URL kumar let me know.
* doesn't return anything about the closing... dunno if you want anything
* fixes #497 