### PR TITLE
Fix subscription_id in braintree_transaction table

### DIFF
--- a/migrations/60-fix-subscription.sql
+++ b/migrations/60-fix-subscription.sql
@@ -1,0 +1,3 @@
+# This was accidentally changed in https://github.com/mozilla/solitude/pull/535
+# This patch puts it back.
+ALTER TABLE `braintree_transaction` CHANGE COLUMN `subscription` `subscription_id` int(11) unsigned;


### PR DESCRIPTION
This column was changed accidentally in
https://github.com/mozilla/solitude/pull/535