### PR TITLE
create a transaction uuid for a sale

### DIFF
--- a/lib/brains/tests/test_sale.py
+++ b/lib/brains/tests/test_sale.py
@@ -95,3 +95,15 @@ class TestSale(BraintreeTest):
         eq_(generic['buyer'], method.braintree_buyer.buyer.get_uri())
         braintree = res.json['mozilla']['braintree']
         eq_(braintree['paymethod'], method.get_uri())
+
+    def test_multiple(self):
+        self.mocks['sale'].create.return_value = successful_method()
+        seller, seller_product = create_seller()
+
+        data = {'amount': 5, 'nonce': 123, 'product_id': 'brick'}
+        res = self.client.post(self.url, data=data)
+        eq_(res.status_code, 200, res.content)
+
+        self.mocks['sale'].create.return_value = successful_method(id='two-id')
+        res = self.client.post(self.url, data=data)
+        eq_(res.status_code, 200, res.content)

--- a/lib/brains/views/sale.py
+++ b/lib/brains/views/sale.py
@@ -39,12 +39,19 @@ def create(request):
         type=constants.TYPE_PAYMENT,
         uid_support=result.transaction.id
     )
+    our_transaction.uuid = our_transaction.create_short_uid()
+    our_transaction.save()
+    log.info('Transaction created: {}'.format(our_transaction.pk))
+
     braintree_transaction = BraintreeTransaction.objects.create(
         kind='submit_for_settlement',
         paymethod=form.cleaned_data['paymethod'],
         transaction=our_transaction,
 
     )
+    log.info('BraintreeTransaction created: {}'
+             .format(braintree_transaction.pk))
+
     res = Namespaced(
         braintree={},  # Not sure if there's anything useful to add here.
         mozilla={

--- a/lib/brains/webhooks.py
+++ b/lib/brains/webhooks.py
@@ -1,5 +1,3 @@
-import time
-
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -8,7 +6,6 @@ from lib.brains.serializers import serialize_webhook
 from lib.transactions import constants
 from lib.transactions.models import Transaction
 from solitude.base import getLogger
-from solitude.utils import shorter
 
 log = getLogger('s.webhooks')
 
@@ -231,17 +228,7 @@ class Processor(object):
                     type=constants.TYPE_PAYMENT,
                     uid_support=their_transaction.id
                 )
-
-                # Make the transaction short and helpful
-                # (14 chars, still 4 chars less than the mocks)
-                our_transaction.uuid = (
-                    'bt-{}-{}'.format(
-                        # Should be unique within this db.
-                        shorter(our_transaction.pk),
-                        # If pk is repeated (eg. in tests, dev) should still
-                        # be unique.
-                        shorter(int(time.time())))
-                )
+                our_transaction.uuid = our_transaction.create_short_uid()
                 our_transaction.save()
 
                 log.info('Transaction created: {}'.format(our_transaction.pk))

--- a/lib/transactions/tests/test_models.py
+++ b/lib/transactions/tests/test_models.py
@@ -88,3 +88,13 @@ class TestModel(APITest):
         data = self.get_data()
         del data['provider']
         Transaction.objects.create(**data)
+
+    def test_short_id(self):
+        obj = Transaction.objects.create(**self.get_data())
+        ok_(obj.create_short_uid().startswith('ba-'))
+
+    def test_short_id_no_provider(self):
+        data = self.get_data()
+        del data['provider']
+        obj = Transaction.objects.create(**data)
+        ok_(obj.create_short_uid().startswith('dk-'))


### PR DESCRIPTION
* fixes #541 
* moves the shorter id creation into the model to make it easier
* adds regression test and a bit of logging just for fun