### PR TITLE
move prefix check

### DIFF
--- a/lib/buyers/tests/test_models.py
+++ b/lib/buyers/tests/test_models.py
@@ -38,6 +38,10 @@ class TestEncryption(TestCase):
         obj = Buyer.objects.create(email='f@f.c')
         assert str(obj.email_sig).startswith('consistent:')
 
+    def test_email_sig_consistent(self):
+        obj = Buyer.objects.create(email='consistent:f')
+        assert str(obj.email_sig) != 'consistent:f'
+
 
 class TestLockout(TestCase):
 


### PR DESCRIPTION
moves the check into `get_prep_value` which only occurs on de-serialization, not serialization, with a test to prove it